### PR TITLE
DA-37: Finally fix the scheme preview and remove it for annotators

### DIFF
--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -188,20 +188,20 @@ angular
                      * @param {type} projectId the projects id
                      */
                     $scope.openProjectSchemeModal = function (projectId) {
-                        for (var i = 0; i < $rootScope.projects.length; i++) {
-                            if ($rootScope.projects[i].id === projectId) {
-                                for (var i = 0; i < $scope.schemes.length; i++) {
-                                    var scheme = $scope.schemes[i];
-                                    for (var j = 0; j < scheme.projects.length; j++) {
-                                        var proj = scheme.projects[j];
-                                        if (proj.id === projectId) {
-                                            $rootScope.currentScheme = scheme;
-                                            break;
-                                        }
-                                    }
+                        
+                        var isSearching = true;
+                        for (var i = 0; i < $scope.schemes.length && isSearching; i++) {
+                            var scheme = $scope.schemes[i];
+                            for (var j = 0; j < scheme.projects.length; j++) {
+                                var proj = scheme.projects[j];
+                                if (proj.id === projectId) {
+                                    $rootScope.currentScheme = scheme;
+                                    isSearching = false;
+                                    break;
                                 }
                             }
                         }
+                        
                         var modalInstance = $uibModal.open({
                             animation: $scope.animationsEnabled,
                             templateUrl: 'templates/schemes/schemeViewModal.html',

--- a/src/main/webapp/controllers/schemes/schemeViewModalController.js
+++ b/src/main/webapp/controllers/schemes/schemeViewModalController.js
@@ -1,14 +1,16 @@
 
 'use strict';
 
-angular.module('app').controller('schemeViewModalController', function ($scope, $rootScope, $http, $sce, $uibModalInstance) {
+angular.module('app').controller('schemeViewModalController', function ($scope, $rootScope, $uibModalInstance) {
 
     $scope.init = function () {
         $scope.loadScheme();
     };
 
     $scope.loadScheme = function () {
-        var scheme = $rootScope.currentScheme;
+        // This is a little hack to make a deep copy of the scheme to set the
+        // projects undefined
+        var scheme = JSON.parse(JSON.stringify($rootScope.currentScheme));
         scheme.projects = undefined;
         for (var j = 0; j < scheme.labelSets.length; j++) {
             var curLabelSet = scheme.labelSets[j];
@@ -24,10 +26,8 @@ angular.module('app').controller('schemeViewModalController', function ($scope, 
                 curLabel.linkSet = undefined;
             }
         }
+        
         $scope.currentScheme = JSON.stringify(scheme, null, "\t");
-
-
-
     };
 
     $scope.submit = function () {

--- a/src/main/webapp/templates/projects/projects.html
+++ b/src/main/webapp/templates/projects/projects.html
@@ -22,7 +22,9 @@
                                 <span ng-hide="isUnprivileged === 'true'">Users</span>
                             </th>
                             <th class="col-md-2 vert-align">Project Manager</th>
-                            <th class="col-md-1 vert-align">Scheme</th>
+                            <th class="col-md-1 vert-align">
+                                <span ng-hide="isUnprivileged === 'true'">Scheme</span>
+                            </th>
                             <th class="col-md-1 vert-align">
                                 <span ng-hide="isUnprivileged === 'true'">Edit Project</span>
                             </th>
@@ -84,7 +86,8 @@
                                 </div>
                             </td>
                             <td class="col-md-2 vert-align">
-                                <p ng-hide="isUnprivileged === 'true'" class="userprogress"
+                                <p ng-hide="isUnprivileged === 'true'"
+                                   class="userprogress"
                                    ng-repeat="cur in x.users">
                                     {{cur.email}}
                                 </p>
@@ -95,7 +98,8 @@
                                 </p>
                             </td>
                             <td class="col-md-1 vert-align">
-                                <a class="glyphicon glyphicon-file"
+                                <a ng-hide="isUnprivileged === 'true'"
+                                   class="glyphicon glyphicon-file"
                                    id="project-scheme-view"
                                    ng-click="openProjectSchemeModal(x.id)">
                                 </a>


### PR DESCRIPTION
The scheme preview wasn't working the second time clicking the button because
the referencing projects were set to undefined for displaying reasons
therefore iterating over the projects was broken. Displaying the scheme
is removed for annotators.
