### PR TITLE
DA-75: Increase cookie security by using HttpOnly

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -2,18 +2,18 @@
 <web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
     <description>DiscAnno Web App</description>
     <session-config>
-        <session-timeout>
-            30
-        </session-timeout>
+        <session-timeout>30</session-timeout>
+        <!-- Preventing XSS attacks. More information:
+             - HttpyOnly flag: https://www.owasp.org/index.php/HttpOnly
+             - secure flag: https://www.owasp.org/index.php/SecureFlag -->
+        <cookie-config>
+            <http-only>true</http-only>
+            <!--TODO when changing to HTTPS <secure>true</secure>-->
+        </cookie-config>
     </session-config>
     <display-name>DiscAnno</display-name>
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
-        <welcome-file>index.jsp</welcome-file>
-        <welcome-file>index.jsp</welcome-file>
-        <welcome-file>default.html</welcome-file>
-        <welcome-file>default.htm</welcome-file>
-        <welcome-file>default.jsp</welcome-file>
     </welcome-file-list>
     <error-page>
         <error-code>404</error-code>


### PR DESCRIPTION
The HttpOnly flag was added to the configuration to prevent XSS attacks.
The secure flag was marked as TODO when the application will use HTTPS
in the future.
