### PR TITLE
DA-50: Disable annotating for admins/ project managers

### DIFF
--- a/src/main/webapp/controllers/dashboardController.js
+++ b/src/main/webapp/controllers/dashboardController.js
@@ -154,6 +154,7 @@ angular
                                 'name': proj.name,
                                 'users': proj.users,
                                 'completed': projCompl,
+								'scheme': proj.scheme,
                                 'numberOfDocuments': proj.documents.length,
                                 'documents': documents,
                                 'pms': proj.projectManager,

--- a/src/main/webapp/controllers/projects/documentAddModalController.js
+++ b/src/main/webapp/controllers/projects/documentAddModalController.js
@@ -33,10 +33,10 @@ angular.module('app').controller('documentAddModalController', function ($scope,
 	 */
     $scope.validateTargets = function (targets, projectId, currFileName) {
         var scheme = null;
-		for (var i = 0; i < $rootScope.projects.length; i++) {
-			var curProj = $rootScope.projects[i];
+		for (var i = 0; i < $rootScope.tableProjects.length; i++) {
+			var curProj = $rootScope.tableProjects[i];
 			if (curProj.id === projectId) {
-			    scheme = $rootScope.projects[i].scheme;
+			    scheme = curProj.scheme;
 			    break;
 			}
         }		    

--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -280,12 +280,13 @@ angular
                                 'scheme': {
                                     'id': full.scheme.id
                                 }
-
                             };
+							
                             $http.post('discanno/project', JSON.stringify(projectTemplate)).then(function (response) {
                                 var template = {
                                     'id': response.data,
                                     'name': full.name,
+									'scheme': projectTemplate.scheme,
                                     'users': [],
                                     'pms': [],
                                     'completed': [],
@@ -295,6 +296,7 @@ angular
 
                                 if ($window.sessionStorage.role != 'projectmanager') {
                                     $rootScope.tableProjects.push(template);
+									$rootScope.projects.push(template);
                                 } else {
                                     // TODO necessary?
                                     //get the current user (there is not REST interface for getUser by ID)
@@ -307,6 +309,7 @@ angular
                                             }
                                         }
                                         $rootScope.tableProjects.push(template);
+										$rootScope.projects.push(template);
                                     }, function () {});
 
                                     // Add project manager to the corresponding proj manager list

--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -31,6 +31,8 @@ angular.module('app')
                     },
                     link: function ($scope, iElement) {
 
+						$scope.isAnnotator = ($window.sessionStorage.isAnnotator === "true");
+
                         var width, height;
                         var lineCount;
                         var textWidth;
@@ -572,7 +574,8 @@ angular.module('app')
                         //Determines what text passage the cursor is currently highlighting
                         //and tries to create a new temporary annotation for that section
                         $scope.$watch('startSelection', function (newVals) {
-                            if (newVals === undefined)
+                            if (newVals === undefined
+									|| !$scope.isAnnotator)
                                 return;
                             var startLine;
                             var startRow;


### PR DESCRIPTION
No text selection is possible if the user is an admin/ project manager.
Before every user could create annotations. Fix one error when
documents are added immediately after the creation of a project.
