### PR TITLE
DA-89: Fix annotation drawing bug

### DIFF
--- a/src/main/webapp/controllers/d3AnnotationController.js
+++ b/src/main/webapp/controllers/d3AnnotationController.js
@@ -10,7 +10,7 @@ angular.module('app')
                     return string !== undefined
                             && (string.length === 1 && (string === "," || string === "." || string === "!" || string === "?"));
                 };
-                
+
                 $scope.isSpace = function (string) {
                     return string !== undefined
                             && (string === " " || string === "");
@@ -23,17 +23,18 @@ angular.module('app')
                         this.endSelection = window.getSelection().getRangeAt(0).endContainer.parentNode;
                     }
                 };
-                
-                this.clearSelection = function() {
+
+                this.clearSelection = function () {
                     if (window.getSelection) {
                         if (window.getSelection().empty)  // Chrome
-                          window.getSelection().empty();
-                        
+                            window.getSelection().empty();
+
                         else if (window.getSelection().removeAllRanges)  // Firefox
-                          window.getSelection().removeAllRanges();
-                        
-                      } 
-                      else if (document.selection)  // IE
+                            window.getSelection().removeAllRanges();
+
+                    } else if (document.selection)  // IE
                         document.selection.empty();
+                    this.startSelection = null;
+                    this.endSelection = null;
                 };
             }]);

--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -631,6 +631,7 @@ angular.module('app')
                             $scope.words = words;
                             $rootScope.ishotkeys = 'false';
                             $scope.setTemp({item: words});
+                            $scope.clearSelection();
                         });
                         //Computes and splits the lines displayed in the annotation field. This is necessary because it is
                         //possible that the lines of the text don't fit into one line of the actual field.


### PR DESCRIPTION
Because the startSelection Object was not reset properly, you could not select the same section again, after deselcting it.
Clear selection is now called after each selection.
