### PR TITLE
DA-121: Compute max-size of right column in editor dynamically

### DIFF
--- a/src/main/webapp/css/annotation.css
+++ b/src/main/webapp/css/annotation.css
@@ -5,6 +5,8 @@
 .scroll-pane
 {
 	overflow: scroll !important;
+          height:auto;
+/*    max-height: 400px;*/
 }
 
 .annotationtitle {

--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -68,6 +68,14 @@ angular.module('app')
                         window.onresize = function () {
                             return $scope.$apply();
                         };
+                        // Recompute max-height of right site on resize, to allow for scrolling
+                        $scope.onResize = function () {
+                            var offset = 150;
+                            $('.scroll-pane').css('max-height', ($(window).height() - offset));
+                        };
+                        $scope.onResize();
+                        angular.element($window).bind('resize', $scope.onResize);
+
                         //Watch scroll behaviour of user to only render important
                         //text segments
                         angular.element($window).bind("scroll", function () {

--- a/src/main/webapp/templates/annotation.html
+++ b/src/main/webapp/templates/annotation.html
@@ -85,7 +85,7 @@
 
         <div class="col-md-5 rightwindow">
             <div ng-class="GraphAccordion">
-                <div class="scroll-pane " style="max-height: 800px;">
+                <div class="scroll-pane ">
                     <uib-accordion close-others="false">
                         <!-- ng-show or ng-hide does not work on uib-accordion-group
                             therefore create a div containing the uib-accordion-group -->


### PR DESCRIPTION
Since the right site of the editor is static, it's max height has to be recomputed on resize.
This allows for the scrollbar to alway be present, even in small browser windows.
