### PR TITLE
DA-119: Add tooltips to nodes and lables/targetTypes

### DIFF
--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -1116,6 +1116,9 @@ angular.module('app')
                                         .attr("fill", function (d) {
                                             return d.annotation.color.fill();
                                         })
+                                        .attr("title", function (d) {
+                                            return d.annotation;
+                                        })
                                         .attr("stroke", function (d) {
                                             return d.annotation.color.back;
                                         })
@@ -1193,8 +1196,20 @@ angular.module('app')
                                                     $scope.setSelection({item: link});
                                                 else
                                                     $scope.setSelection({item: d.annotation});
-                                            });
-                                        });
+                                            })
+                                        })
+                                        .append("svg:title").text(function (d) {
+                                    var ret = "";
+                                    for (var key in d.annotation.activeLabels) {
+                                        var set = d.annotation.activeLabels[key];
+                                        for (var i = 0; i < set.length; i++) {
+                                            ret += (set[i].tag + " ");
+                                        }
+                                    }
+                                    return 'Type: ' + d.annotation.tType.tag + " | Labels: " + ret;
+
+                                });
+
                                 //Draw the actual annotation text
                                 svg.selectAll("annotations")
                                         .data(annotationBoxes)
@@ -1279,7 +1294,17 @@ angular.module('app')
                                                 else
                                                     $scope.setSelection({item: d.annotation});
                                             });
-                                        });
+                                        }).append("svg:title").text(function (d) {
+                                    var ret = "";
+                                    for (var key in d.annotation.activeLabels) {
+                                        var set = d.annotation.activeLabels[key];
+                                        for (var i = 0; i < set.length; i++) {
+                                            ret += (set[i].tag + " ");
+                                        }
+                                    }
+                                    return 'Type: ' + d.annotation.tType.tag + " | Labels: " + ret;
+
+                                });
                             }
                         };
                         //Draw the links as lines between the corresponding annotation boxes

--- a/src/main/webapp/directives/d3Options.js
+++ b/src/main/webapp/directives/d3Options.js
@@ -223,6 +223,9 @@ angular.module('app')
                                     .attr("id", function (d) {
                                         return "tt_" + d.value.tag;
                                     })
+                                    .attr("title", function (d) {
+                                        return d.value.tag;
+                                    })
                                     .classed("btn btn-default btn-xs", true)
                                     // TODO: create utility function for the two functions below
                                     .classed("btn-default", function (d) {
@@ -318,6 +321,9 @@ angular.module('app')
                                                 return true;
                                             }
                                             return false;
+                                        })
+                                        .attr("title", function (d) {
+                                            return d.tag;
                                         })
                                         .attr("disabled", function () {
                                             if (!$scope.isAnnotator) {


### PR DESCRIPTION
Tooltips have been added to labels and targets with the html title-attribute.
In the text it has been done via the title svg tag. THIS MIGHT DECREASE PERFORMANCE.
