### PR TITLE
DA-123: Fix PM opening a doc directly after creation

### DIFF
--- a/src/main/webapp/controllers/projects/documentAddModalController.js
+++ b/src/main/webapp/controllers/projects/documentAddModalController.js
@@ -109,7 +109,7 @@ angular.module('app').controller('documentAddModalController', function ($scope,
                     return function (response) {
                         var docTemplate = {
                             'completed': 0,
-                            'id': response,
+                            'id': response.data,
                             'name': curFileName
                         };
                         for (var i = 0; i < $rootScope.tableProjects.length; i++) {


### PR DESCRIPTION
Befor an exception was thrown, because the wrong docId was handed to the 'openAnnoTool' method.
This was due to the wrong saving of the id in the documentAddModalController.
The whole response object was saved as the id, instead of just the data.
