### PR TITLE
DA-160: Disable "add" buttons on project edit modal when no user / PM selected

### DIFF
--- a/src/main/webapp/controllers/projects/projectEditModalController.js
+++ b/src/main/webapp/controllers/projects/projectEditModalController.js
@@ -67,6 +67,7 @@ angular
                         break;
                     }
                 }
+                $scope.newUser = undefined;
             }).error(function (response) {
                 $rootScope.checkResponseStatusCode(response.status);
             });
@@ -85,6 +86,7 @@ angular
                         }
                     }
                 }
+                $scope.newPM = undefined;
             }).error(function (response) {
                 $rootScope.checkResponseStatusCode(response.status);
             });

--- a/src/main/webapp/templates/projects/projectEditModal.html
+++ b/src/main/webapp/templates/projects/projectEditModal.html
@@ -51,7 +51,7 @@ and open the template in the editor.
                         <select ng-model="newPM"
                                 ng-options="pm.id as pm.email for pm in (getUserComplement(this.pms, this.projPms)| orderBy: '-email')">
                         </select>
-                        <button class="btn btn-primary" ng-click="addSelectedPM()">
+                        <button class="btn btn-primary"  ng-disabled="newPM === undefined" ng-click="addSelectedPM()">
                             Add
                         </button>
                     </div>
@@ -79,7 +79,7 @@ and open the template in the editor.
                         <select ng-model="newUser"
                                 ng-options="user.id as user.email for user in (getUserComplement(this.users, this.projUsers)| orderBy: '-email')">
                         </select>
-                        <button class="btn btn-primary" ng-click="addSelectedUser()">
+                        <button class="btn btn-primary" ng-disabled="newUser === undefined" ng-click="addSelectedUser()">
                             Add
                         </button>
                     </div>


### PR DESCRIPTION
Previously, it was possible to click the "add" buttons when no user / PM was selected, which resulted in an error.
This is now prevented by disabling the buttons unless a user / PM is selected.
