### PR TITLE
DA-157: Do not throw error when links not matching.

### DIFF
--- a/src/main/webapp/controllers/annotationController.js
+++ b/src/main/webapp/controllers/annotationController.js
@@ -565,8 +565,11 @@ angular
                         deferred.reject(undefined);
                     });
 
-                    return deferred.promise;
+                } else {
+                    deferred.reject(undefined);
                 }
+
+                return deferred.promise;
             };
             //Checks if two annotations are linkable depending on their target type
             this.linkable = function (source, target) {


### PR DESCRIPTION
Previously trying to link unmatching spantypes caused uncaught
TypeError.
