### PR TITLE
DA-185: Allow new admins and project managers to be added by admins

### DIFF
--- a/src/main/webapp/controllers/users/userAddModalController.js
+++ b/src/main/webapp/controllers/users/userAddModalController.js
@@ -7,10 +7,11 @@
 
 angular
     .module('app')
-    .controller('userAddModalController', function ($scope, $rootScope, $http, $uibModalInstance) {
+    .controller('userAddModalController', function ($scope, $rootScope, $http, $window, $uibModalInstance) {
 
         // Initialize User View
         $scope.init = function () {
+            $scope.role = $window.sessionStorage.role;
             $scope.availableRoles = [{name: "Annotator", value: "annotator"}];
             if ($scope.role === "admin") {
                 $scope.availableRoles.push({value: "admin", name: "Admin"});


### PR DESCRIPTION
Previously, it was impossible for admins to add new users as admins or project
managers. The patch fixes this by informing the "add user" modal of the role of
the current user, so that the correct options are displayed.
