### PR TITLE
DA-182: Fix error when unselecting annotation labels

### DIFF
--- a/src/main/webapp/other/annotationStructures.js
+++ b/src/main/webapp/other/annotationStructures.js
@@ -97,12 +97,15 @@ function AnnotationObject(id, type, labels, text) {
 
             if (set.exclusive) {
                 this.activeLabels[set.id] = [];
-                if (!removed)
+                if (!removed) {
                     this.activeLabels[set.id].push(label);
+                } else {
+                    delete this.activeLabels[set.id];
+                }
             } else {
-                if (!removed)
+                if (!removed) {
                     this.activeLabels[set.id].push(label);
-                else {
+                } else {
                     if (this.activeLabels[set.id].length === 0)
                         delete this.activeLabels[set.id];
                 }


### PR DESCRIPTION
Unselecting exclusive annotation labels evoked an error
because the corresponding (empty) activeLabels list
was not deleted.
