### PR TITLE
DA-158: Fix error that occurs when deleting linked annotation

### DIFF
--- a/src/main/webapp/controllers/annotationController.js
+++ b/src/main/webapp/controllers/annotationController.js
@@ -477,16 +477,18 @@ angular
             //Deletes an annotation and makes a callback to the backend
             this.removeAnnotation = function (annotation) {
                 this.sizeIncreased = undefined;
-                this.lastRemoved = annotation;
                 if (annotation === this.tempAnno) {
                     this.tempAnno.onDelete();
                     this.tempAnno = null;
+                    this.lastRemoved = annotation;
                 } else {
+                    var annoCtrl = this;
                     $http.delete("discanno/annotations/" + annotation.id).then(function (object) {
                         return function (response) {
+                            object.removeConnectedLinks(annotation);
+                            annoCtrl.lastRemoved = annotation;
                             annotation.onDelete();
                             delete object.annotationData[annotation.id];
-                            object.removeConnectedLinks(annotation);
                         };
                     }(this), function (err) {
                         $rootScope.checkResponseStatusCode(err.status);


### PR DESCRIPTION
Previously, deleting an annotation with links attached to it
resulted in an error. This was caused by the following chain of
events:
1. annotationController.removeAnnotation(annotation) is called.
2. During the execution of the function, annotationController.lastRemoved
   is changed to annotation.
3. As a result, formAnnotations[annotation.id] is deleted in d3Annotation.
4. annotationController.removeAnnotation(annotation) then calls
   removeConnectedLinks(annotation).
5. As a result, d3Annotation calls drawLinks().
6. drawLinks() tries to access the sources and targets of each
   link, via formAnnotations. However, one of them has just
   been deleted (step 3). This results in an error, since
   the source/target is thus undefined.

This issue has been solved by changing the order of removal:
Now, the relevant links are removed before the annotation itself.
