### PR TITLE
DA-190: Optimize project request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.classpath
 /.settings/
 /nbactions.xml
+/src/main/webapp/npm-debug.log
 /npm-debug.log
 /Project1_Politics1_John_Locke.xml
 /export.zip

--- a/src/main/java/de/unisaarland/discanno/business/Service.java
+++ b/src/main/java/de/unisaarland/discanno/business/Service.java
@@ -456,7 +456,7 @@ public class Service {
 
         switch (user.getRole()) {
             case admin:
-                list = projectDAO.findAll();
+                list = projectDAO.getAllProjectsAsAdmin();
                 break;
             case projectmanager:
                 list = projectDAO.getAllProjectsAsProjectManagerByUserId(userId);

--- a/src/main/java/de/unisaarland/discanno/dao/ProjectDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/ProjectDAO.java
@@ -24,6 +24,24 @@ public class ProjectDAO extends BaseEntityDAO<Project> {
         super(Project.class);
     }
 
+    public List<Project> getAllProjectsAsAdmin() {
+        return findAll();
+
+        /*
+         TODO we should optimize the fetching strategy probably via
+         a manual SQL query so that we do not fetch the documents text
+         attribute etc.
+
+        final String strQuery = "SELECT p.id, p.name, p.scheme " +
+                                "FROM Project AS p " +
+                                "JOIN p.documents docs GROUP BY docs.project " +
+                                "JOIN p.users users";
+
+        return em.createQuery(strQuery, Project.class).getResultList();
+        */
+    }
+
+
     /**
      * Returns a list of all projects whose user id is included
      * in the the projects users list. Currently used to

--- a/src/main/java/de/unisaarland/discanno/entities/Document.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Document.java
@@ -54,7 +54,8 @@ public class Document extends BaseEntity {
     
     @JsonView({ View.Documents.class, View.Projects.class })
     @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE },
-                mappedBy = "document")
+                mappedBy = "document",
+                fetch = FetchType.EAGER)
     private Set<State> states = new HashSet<>();
     
     /**
@@ -62,7 +63,8 @@ public class Document extends BaseEntity {
      * They do not have an user id.
      */
     @JsonView({ View.Documents.class })
-    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE }, fetch = FetchType.EAGER)
+    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE },
+                fetch = FetchType.LAZY)
     @JoinTable(
         name="DOCUMENT_DEFAULTANNOTATIONS",
         joinColumns={@JoinColumn(name="DOC_ID", referencedColumnName="id")},


### PR DESCRIPTION
Requesting all projects was pretty slow since a special amount of data.
The fetching strategy was changed so that some child attributes are
loaded lazily and some eager to optimize the query.
