### PR TITLE
DA-52: Don't close scheme builder when clicking outside modal

### DIFF
--- a/src/main/webapp/controllers/schemes/schemesController.js
+++ b/src/main/webapp/controllers/schemes/schemesController.js
@@ -140,7 +140,8 @@ angular
                 animation: $scope.animationsEnabled,
                 templateUrl: 'templates/schemes/schemeUploadModal.html',
                 controller: 'schemeUploadModalController',
-                size: 'lg'
+                size: 'lg',
+                backdrop: false
             });
 
             modalInstance.result.then(function (response) {

--- a/src/main/webapp/templates/schemes/schemeUploadModal.html
+++ b/src/main/webapp/templates/schemes/schemeUploadModal.html
@@ -15,6 +15,7 @@ and open the template in the editor.
         <!-- Project Modal -->
         <form role="form">
             <div class="modal-header">
+                <button type="button" class="close" ng-click="cancel()" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 <h3 class="modal-title" id="myModalLabel">Scheme builder</h3>
             </div>
             <div class="col-lg-6">
@@ -407,6 +408,7 @@ and open the template in the editor.
                 </uib-alert>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-default" ng-click="cancel()" data-dismiss="modal">Cancel</button>
                 <button id="sb_submitSchemeButton"
                         type="button"
                         class="btn btn-primary"


### PR DESCRIPTION
Clicking outside the scheme builder modal does not lead to closing
anymore. Cancel buttons were added.
