### PR TITLE
DA-204: Remove loading of all Project information, when opening a pro…

### DIFF
--- a/src/main/webapp/controllers/annotationController.js
+++ b/src/main/webapp/controllers/annotationController.js
@@ -77,12 +77,7 @@ angular
                 if ($scope.shownUserList === undefined) {
                     $scope.shownUserList = {};
                 }
-
-                var xmlHttp = new XMLHttpRequest();
-                xmlHttp.open("GET", "discanno/document/" + $window.sessionStorage.docId, false); // false for synchronous request
-                xmlHttp.send(null);
-                var resp = xmlHttp.responseText;
-                $scope.users = JSOG.parse(resp).project.users;
+                $scope.users = JSON.parse($window.sessionStorage.users);
                 if ($window.sessionStorage.shownUser === "undefined"
                         || $window.sessionStorage.shownUser === undefined
                         || $window.sessionStorage.shownUser == $window.sessionStorage.uId) {

--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -146,9 +146,11 @@ angular
              * @param {String} projectName the Projects name
              * @param {Boolean} completed state of the document
              */
-            $scope.openAnnoTool = function (docId, docName, projectName, completed) {
+            $scope.openAnnoTool = function (docId, docName, projectName, completed, users) {
                 $scope.alertVisible = true;
                 $rootScope.initAnnoTool(docId, docName, projectName, completed);
+                //Variables in the sessionStorage have to be Strings
+                $window.sessionStorage.users = JSON.stringify(users);
                 $location.path('/annotation');
             };
 

--- a/src/main/webapp/templates/projects/projects.html
+++ b/src/main/webapp/templates/projects/projects.html
@@ -208,11 +208,11 @@ and open the template in the editor.
                                     <!-- Show open eye for admin/ project manager and pencil for user -->
                                     <span class="glyphicon glyphicon-eye-open"
                                           ng-hide="isUnprivileged === 'true'"
-                                          ng-click="openAnnoTool(doc.id, doc.name, x.name, doc.completed)">
+                                          ng-click="openAnnoTool(doc.id, doc.name, x.name, doc.completed, x.users)">
                                     </span>
                                     <span class="glyphicon glyphicon-pencil"
                                           ng-hide="isUnprivileged === 'false'"
-                                          ng-click="openAnnoTool(doc.id, doc.name, x.name, doc.completed)">
+                                          ng-click="openAnnoTool(doc.id, doc.name, x.name, doc.completed, x.users)">
                                     </span>
                                 </a>
                             </td>


### PR DESCRIPTION
…ject as PM/Admin

Before, when opening a document as a PM/Admin all documents present in a project were requested, just to get the users assigned to project.
Now the information about assigned users is carried over from the ProjectExplorer
