### PR TITLE
DA-190: Increase performance of projects, documents and scheme requests

### DIFF
--- a/src/main/java/de/unisaarland/discanno/business/Service.java
+++ b/src/main/java/de/unisaarland/discanno/business/Service.java
@@ -459,10 +459,10 @@ public class Service {
                 list = projectDAO.getAllProjectsAsAdmin();
                 break;
             case projectmanager:
-                list = projectDAO.getAllProjectsAsProjectManagerByUserId(userId);
+                list = projectDAO.getAllProjectsAsProjectManagerByUser(user);
                 break;
             case annotator:
-                list = projectDAO.getAllProjectsByUserId(userId);
+                list = projectDAO.getAllProjectsByUser(user);
                 break;
         }
 

--- a/src/main/java/de/unisaarland/discanno/dao/ProjectDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/ProjectDAO.java
@@ -6,11 +6,13 @@
 package de.unisaarland.discanno.dao;
 
 import de.unisaarland.discanno.entities.Project;
+import de.unisaarland.discanno.entities.Users;
+
+import java.util.Collections;
 import java.util.List;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.persistence.Query;
 
 /**
  * This DAO (Data Access Object) provides all CRUD operations for projects.
@@ -29,25 +31,18 @@ public class ProjectDAO extends BaseEntityDAO<Project> {
         return executeQuery(Project.QUERY_FIND_ALL);
     }
 
-
     /**
      * Returns a list of all projects whose user id is included
      * in the the projects users list. Currently used to
      * retrieve all projects by users with user role 'annotator'.
      *
-     * @param userId
+     * @param user
      * @return
      */
-    public List<Project> getAllProjectsByUserId(final Long userId) {
-
-        final String strQuery = "SELECT * " +
-                                "FROM project p " +
-                                "WHERE EXISTS(SELECT 1 " +
-                                        "FROM users_projects up " +
-                                        "WHERE up.users_id = ? AND p.id = up.project_id)";
-        return em.createNativeQuery(strQuery, Project.class)
-                .setParameter(1, userId)
-                .getResultList();
+    public List<Project> getAllProjectsByUser(final Users user) {
+        return executeQuery(
+                Project.QUERY_FIND_PROJECTS_BY_USER,
+                Collections.singletonMap(Project.PARAM_USER, user));
     }
 
     /**
@@ -55,20 +50,13 @@ public class ProjectDAO extends BaseEntityDAO<Project> {
      * in the projects projectsManager list. Only used for project
      * manager.
      *
-     * @param userId
+     * @param user
      * @return
      */
-    public List<Project> getAllProjectsAsProjectManagerByUserId(final Long userId) {
-
-        final String strQuery = "SELECT * " +
-                                "FROM project p " +
-                                "WHERE EXISTS(SELECT 1 " +
-                                        "FROM PROJECTS_MANAGER pm " +
-                                        "WHERE pm.manager_id = ? AND p.id = pm.project_id)";
-
-        return em.createNativeQuery(strQuery, Project.class)
-                .setParameter(1, userId)
-                .getResultList();
+    public List<Project> getAllProjectsAsProjectManagerByUser(final Users user) {
+        return executeQuery(
+                Project.QUERY_FIND_PROJECTS_BY_PROJECT_MANAGER,
+                Collections.singletonMap(Project.PARAM_USER, user));
     }
-    
+
 }

--- a/src/main/java/de/unisaarland/discanno/dao/SchemeDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/SchemeDAO.java
@@ -9,6 +9,8 @@ import de.unisaarland.discanno.entities.Scheme;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This DAO (Data Access Object) provides all CRUD operations for schemes.
@@ -22,22 +24,24 @@ public class SchemeDAO extends BaseEntityDAO<Scheme> {
     public SchemeDAO() {
         super(Scheme.class);
     }
-    
-    
-    public Scheme getSchemeByDocId(Long docId) {
 
-        final String strQuery = "SELECT * " +
-                                "FROM SCHEME s " +
-                                "WHERE EXISTS(SELECT 1 " +
-                                            "FROM PROJECT p " +
-                                            "WHERE EXISTS(SELECT 1 " +
-                                                            "FROM DOCUMENT d " +
-                                                            "WHERE d.id = ? AND project_fk = p.id) " +
-                                            "AND p.scheme = s.id)";
-        
-        return (Scheme) em.createNativeQuery(strQuery, Scheme.class)
-                            .setParameter(1, docId)
-                            .getSingleResult();
+    @Override
+    public List<Scheme> findAll() {
+        return executeQuery(Scheme.QUERY_FIND_ALL);
+    }
+
+    public Scheme find(final Long schemeId) {
+        return firstResult(
+                    executeQuery(
+                        Scheme.QUERY_FIND_BY_ID,
+                        Collections.singletonMap(Scheme.PARAM_SCHEME_ID, schemeId)));
+    }
+
+    public Scheme getSchemeByDocId(final Long docId) {
+        return firstResult(
+                executeQuery(
+                        Scheme.QUERY_FIND_BY_DOC_ID,
+                        Collections.singletonMap(Scheme.PARAM_DOC_ID, docId)));
     }
     
 }

--- a/src/main/java/de/unisaarland/discanno/entities/Annotation.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Annotation.java
@@ -81,21 +81,25 @@ public class Annotation extends BaseEntity {
     public static final String PARAM_USER = "user";
     
     @JsonView({ View.Annotations.class, View.Links.class })
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.EAGER, optional = true)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+                fetch = FetchType.EAGER, optional = true)
     @JoinColumn(name="user_fk")
     private Users user;
     
     @JsonView({ View.Annotations.class, View.Links.class })
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+                fetch = FetchType.LAZY)
     @JoinColumn(name = "document_fk")
     private Document document;
     
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.EAGER)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+                fetch = FetchType.EAGER)
     @JoinColumn(name = "targetType_fk")
     private TargetType targetType;
     
     @JsonView({ View.Annotations.class, View.Links.class })
-    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.EAGER)
+    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+                fetch = FetchType.EAGER)
     @JoinTable(
         name="ANNOTATION_LABELMAP",
         joinColumns={@JoinColumn(name="ANNOTATION_ID", referencedColumnName="id")},

--- a/src/main/java/de/unisaarland/discanno/entities/BaseEntity.java
+++ b/src/main/java/de/unisaarland/discanno/entities/BaseEntity.java
@@ -23,6 +23,7 @@ public class BaseEntity implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @JsonView({View.Annotations.class,
+        View.Scheme.class,
         View.Schemes.class,
         View.Users.class,
         View.Login.class,

--- a/src/main/java/de/unisaarland/discanno/entities/Document.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Document.java
@@ -52,7 +52,7 @@ public class Document extends BaseEntity {
     private String name;
     
     /**
-     * The column definiton "TEXT" determines the database type.
+     * The column definition "TEXT" determines the database type.
      * From character varying(255) to "text"
      */
     @JsonView({ View.Documents.class })
@@ -62,7 +62,8 @@ public class Document extends BaseEntity {
     
     @JsonView({ View.Documents.class })
     @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-                optional = false)
+                optional = false,
+                fetch = FetchType.LAZY)
     @JoinColumn(name = "project_fk")
     private Project project;
     

--- a/src/main/java/de/unisaarland/discanno/entities/LabelSet.java
+++ b/src/main/java/de/unisaarland/discanno/entities/LabelSet.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @JsonIdentityInfo(generator=JSOGGenerator.class)
 public class LabelSet extends BaseEntity {
 
-    @JsonView({ View.Schemes.class })
+    @JsonView({ View.Scheme.class })
     @Column(name = "Name")
     private String name;
     
@@ -42,14 +42,14 @@ public class LabelSet extends BaseEntity {
      * Determines whether an annotation refers to several labels or
      * one.
      */
-    @JsonView({ View.Schemes.class })
+    @JsonView({ View.Scheme.class })
     @Column(name = "Exclusive")
     private boolean exclusive;
 
     /**
      * Contains the targettypes which can be annotated with this label.
      */
-    @JsonView({ View.Schemes.class })
+    @JsonView({ View.Scheme.class })
     @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
     @JoinTable(
         name="TARGETTYPE_LABELSET",
@@ -57,7 +57,7 @@ public class LabelSet extends BaseEntity {
         inverseJoinColumns={@JoinColumn(name="TARGETTYPE", referencedColumnName="TargetType")})
     private Set<TargetType> appliesToTargetTypes = new HashSet<>();
     
-    @JsonView({ View.Schemes.class })
+    @JsonView({ View.Scheme.class })
     @ManyToMany(mappedBy = "labelSet",
                 cascade = { CascadeType.PERSIST, CascadeType.MERGE },
                 fetch = FetchType.EAGER)

--- a/src/main/java/de/unisaarland/discanno/entities/LinkLabel.java
+++ b/src/main/java/de/unisaarland/discanno/entities/LinkLabel.java
@@ -38,7 +38,7 @@ public class LinkLabel implements Serializable {
 
     private static final long serialVersionUID = 1L;
     
-    @JsonView({ View.Links.class, View.Schemes.class })
+    @JsonView({ View.Links.class, View.Scheme.class })
     @Id
     @Column(name = "LinkLabel")
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/de/unisaarland/discanno/entities/LinkSet.java
+++ b/src/main/java/de/unisaarland/discanno/entities/LinkSet.java
@@ -23,13 +23,13 @@ import javax.persistence.ManyToOne;
  * 
  * The JsonIdentityInfo annotations prevents infinite recursions.
  *
- * @author Janna Herrmann
+ * @author Timo Guehring
  */
 @Entity
 @JsonIdentityInfo(generator=JSOGGenerator.class)
 public class LinkSet extends BaseEntity {
     
-    @JsonView({ View.Schemes.class })
+    @JsonView({ View.Scheme.class })
     @Column(name = "Name")
     private String name;
     
@@ -46,7 +46,7 @@ public class LinkSet extends BaseEntity {
     @Column(name = "AllowUnlabeledLinks")
     private boolean allowUnlabeledLinks;
     
-    @JsonView({ View.Schemes.class })
+    @JsonView({ View.Scheme.class })
     @ManyToMany(mappedBy = "linkSet",
                 cascade = { CascadeType.PERSIST, CascadeType.MERGE },
                 fetch = FetchType.EAGER)

--- a/src/main/java/de/unisaarland/discanno/entities/TargetType.java
+++ b/src/main/java/de/unisaarland/discanno/entities/TargetType.java
@@ -28,14 +28,14 @@ import javax.persistence.ManyToMany;
  * 
  * The JsonIdentityInfo annotations prevents infinite recursions.
  * 
- * @author Janna Herrmann
+ * @author Timo Guehring
  */
 @Entity
 @JsonIdentityInfo(generator=JSOGGenerator.class)
 public class TargetType implements Serializable {
     
     private static final long serialVersionUID = 1L;
-    @JsonView({ View.Schemes.class, View.Annotations.class })
+    @JsonView({ View.Scheme.class, View.Annotations.class })
     @Id
     @Column(name = "TargetType")
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -44,7 +44,7 @@ public class TargetType implements Serializable {
     @JsonIgnore
     @ManyToMany(mappedBy = "appliesToTargetTypes",
                 cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-                fetch = FetchType.EAGER)
+                fetch = FetchType.LAZY)
     private List<LabelSet> labelSets = new ArrayList<>();
 
     public String getTargetType() {

--- a/src/main/java/de/unisaarland/discanno/entities/Users.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Users.java
@@ -126,7 +126,8 @@ public class Users extends BaseEntity {
     private Timestamp createDate;
     
     @JsonView({ View.Users.class })
-    @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
+    @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+            fetch = FetchType.LAZY)
     @JoinTable(
         name="USERS_PROJECTS",
         joinColumns={@JoinColumn(name="USERS_ID", referencedColumnName="id")},

--- a/src/main/java/de/unisaarland/discanno/rest/services/v1/ProjectFacadeREST.java
+++ b/src/main/java/de/unisaarland/discanno/rest/services/v1/ProjectFacadeREST.java
@@ -22,9 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.ejb.CreateException;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
+import javax.ejb.*;
 import javax.persistence.NoResultException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -54,7 +52,7 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
     
     @EJB
     UsersDAO usersDAO;
-    
+
     @EJB
     ProjectDAO projectDAO;
     

--- a/src/main/java/de/unisaarland/discanno/rest/services/v1/SchemeFacadeREST.java
+++ b/src/main/java/de/unisaarland/discanno/rest/services/v1/SchemeFacadeREST.java
@@ -59,7 +59,7 @@ public class SchemeFacadeREST extends AbstractFacade<Scheme> {
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
             service.process(entity);
-            return usersDAO.create(entity);
+            return schemeDAO.create(entity);
         } catch (SecurityException e) {
             return Response.status(Response.Status.FORBIDDEN).build();
         } catch (CreateException ex) {
@@ -94,7 +94,29 @@ public class SchemeFacadeREST extends AbstractFacade<Scheme> {
 
             Scheme scheme = schemeDAO.getSchemeByDocId(docId);
 
-            return Response.ok(mapper.writerWithView(View.Schemes.class)
+            return Response.ok(mapper.writerWithView(View.Scheme.class)
+                                        .withRootName("scheme")
+                                        .writeValueAsString(scheme))
+                            .build();
+        } catch (SecurityException e) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        } catch (JsonProcessingException ex) {
+            Logger.getLogger(SchemeFacadeREST.class.getName()).log(Level.SEVERE, null, ex);
+            return Response.serverError().build();
+        }
+    }
+
+    @GET
+    @Path("/byid/{schemeId}")
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getSchemeById(@PathParam("schemeId") Long schemeId) {
+
+        try {
+            LoginUtil.check(usersDAO.checkLogin(getSessionID()));
+
+            Scheme scheme = schemeDAO.find(schemeId);
+
+            return Response.ok(mapper.writerWithView(View.Scheme.class)
                                         .withRootName("scheme")
                                         .writeValueAsString(scheme))
                             .build();

--- a/src/main/java/de/unisaarland/discanno/rest/view/View.java
+++ b/src/main/java/de/unisaarland/discanno/rest/view/View.java
@@ -13,7 +13,8 @@ package de.unisaarland.discanno.rest.view;
  */
 public class View {
     
-    public static class Schemes {}
+    public static class Schemes {}      // Multiple schemes
+    public static class Scheme {}       // Single scheme
     public static class Annotations {}
     public static class Documents {}
     public static class Links {}

--- a/src/main/java/de/unisaarland/discanno/tokenization/TokenizationUtil.java
+++ b/src/main/java/de/unisaarland/discanno/tokenization/TokenizationUtil.java
@@ -16,19 +16,21 @@ import java.util.regex.Pattern;
 public class TokenizationUtil {
 
     private static final Pattern LINEBREAK_PATTERN = Pattern.compile("\r\n|\r|\n");
-    
+    private static final String OPTIONS = "ptb3Escaping=false,normalizeParentheses=false,normalizeOtherBrackets=false";
+
     public static List<Line> tokenize(String str) {
         Token wsToken;
         Token wsToken2;
         String lineInSubstr;
         StringReader reader = new StringReader(str);
-        PTBTokenizer ptbt = new PTBTokenizer((Reader) reader, (LexedTokenFactory) new CoreLabelTokenFactory(), "ptb3Escaping=false,normalizeParentheses=false,normalizeOtherBrackets=false");
+        PTBTokenizer ptbt = new PTBTokenizer(reader, new CoreLabelTokenFactory(), OPTIONS);
         Line line = new Line();
-        ArrayList<Line> lines = new ArrayList<Line>();
+        ArrayList<Line> lines = new ArrayList<>();
         int docIdx = 0;
+
         while (ptbt.hasNext()) {
             CoreLabel label = (CoreLabel) ptbt.next();
-            //System.out.println("label: " + (Object) label);
+
             while (label.beginPosition() > docIdx) {
                 String subStr = str.substring(docIdx, label.beginPosition());
                 String[] linesInSubstr = subStr.split("\\r?\\n", -1);
@@ -42,8 +44,8 @@ public class TokenizationUtil {
                         wsToken2 = TokenizationUtil.createToken(docIdx, docIdx + lineInSubstr.length(), lineInSubstr);
                         line.addTokens(wsToken2);
                         lines.add(line);
-                        //System.out.println("NEWLINE");
                         line = new Line();
+
                         docIdx = docIdx + lineInSubstr.length();
                         if (str.substring(docIdx).startsWith("\r")) {
                             ++docIdx;
@@ -66,10 +68,9 @@ public class TokenizationUtil {
                         if (str.substring(docIdx).startsWith("\n")) {
                             ++docIdx;
                         }
+
                         lines.add(line);
-                        //System.out.println("NEWLINE--3 " + docIdx);
                         line = new Line();
-                        
                     }
                 }
             }
@@ -77,6 +78,7 @@ public class TokenizationUtil {
             line.addTokens(token);
             docIdx = label.endPosition();
         }
+
         if (str.length() > docIdx) {
             String subStr = str.substring(docIdx);
             String[] linesInSubstr = subStr.split("\\r?\\n", -1);
@@ -105,25 +107,25 @@ public class TokenizationUtil {
                     if (str.substring(docIdx).startsWith("\n")) {
                         ++docIdx;
                     }
+
                     lines.add(line);
-                    //System.out.println("NEW LINE");
                     line = new Line();
                 }
             }
         }
+
         lines.add(line);
-        //System.out.println("NEW LINE");
         return lines;
     }
     
     public static HashMap<String, HashMap<Integer, CoreLabel>> getTokenMap(String str) {
         StringReader reader = new StringReader(str);
-        HashMap<Integer, CoreLabel> mapStart = new HashMap<Integer, CoreLabel>();
-        HashMap<Integer, CoreLabel> mapEnd = new HashMap<Integer, CoreLabel>();
-        HashMap<String, HashMap<Integer, CoreLabel>> maps = new HashMap<String, HashMap<Integer, CoreLabel>>();
+        HashMap<Integer, CoreLabel> mapStart = new HashMap<>();
+        HashMap<Integer, CoreLabel> mapEnd = new HashMap<>();
+        HashMap<String, HashMap<Integer, CoreLabel>> maps = new HashMap<>();
         maps.put("start", mapStart);
         maps.put("end", mapEnd);
-        PTBTokenizer ptbt = new PTBTokenizer((Reader) reader, (LexedTokenFactory) new CoreLabelTokenFactory(), "ptb3Escaping=false,normalizeParentheses=false,normalizeOtherBrackets=false");
+        PTBTokenizer ptbt = new PTBTokenizer(reader, new CoreLabelTokenFactory(), OPTIONS);
         while (ptbt.hasNext()) {
             CoreLabel label = (CoreLabel) ptbt.next();
             mapStart.put(label.beginPosition(), label);
@@ -132,8 +134,7 @@ public class TokenizationUtil {
         return maps;
     }
     
-    private static Token createToken(int start, int end, String text) {
-        //System.out.println("creating token: " + start + " " + end + " >" + text + "<");
+    private static Token createToken(final int start, final int end, final String text) {
         Token token = new Token();
         token.setStart(start);
         token.setEnd(end);

--- a/src/main/webapp/controllers/profile/profileController.js
+++ b/src/main/webapp/controllers/profile/profileController.js
@@ -53,13 +53,6 @@ angular
             }
         };
 
-        $scope.getUser = function () {
-            $scope.prename = $window.sessionStorage.prename;
-            $scope.lastname = $window.sessionStorage.lastname;
-            $scope.email = $window.sessionStorage.email;
-            $scope.role = $window.sessionStorage.role;
-        };
-
         $scope.getTime = function () {
             $scope.tilog = [];
             $http.get("swan/timelogging/" + $scope.userId).success(function (response) {

--- a/src/main/webapp/controllers/projects/documentAddModalController.js
+++ b/src/main/webapp/controllers/projects/documentAddModalController.js
@@ -38,10 +38,7 @@ angular
          * @param {type} currFileName
          */
         $scope.validateTargets = function (targets, projectId, currFileName) {
-
-        	const curProj = $rootScope.getProjectByProjectId(projectId, $rootScope.tableProjects);
-            const scheme = $rootScope.getSchemeBySchemeId(curProj.scheme.id, $rootScope.schemes);
-
+            const scheme = $rootScope.currScheme;
             const tTypeMap = $scope.getTargetTypeMap(scheme);
             for (var i = 0; i < targets.targets.length; i++) {
                 var target = targets.targets[i];

--- a/src/main/webapp/controllers/rootController.js
+++ b/src/main/webapp/controllers/rootController.js
@@ -43,8 +43,18 @@ angular
             }
         };
 
+        $scope.getUser = function () {
+            $scope.prename = $window.sessionStorage.prename;
+            $scope.lastname = $window.sessionStorage.lastname;
+            $scope.email = $window.sessionStorage.email;
+            $scope.role = $window.sessionStorage.role;
+        };
+
+        // Explicit call here
         $rootScope.validateSignedInUser();
+        $scope.getUser();
         $rootScope.isUnprivileged = $window.sessionStorage.isAnnotator;
+
 
         $scope.logout = function () {
             $http.post('swan/usermanagment/logout');

--- a/src/main/webapp/controllers/schemes/schemeUploadModalController.js
+++ b/src/main/webapp/controllers/schemes/schemeUploadModalController.js
@@ -510,57 +510,10 @@ angular
                 $scope.loadedSchemes = [];
                 for (var i = 0; i < schemes.length; i++) {
                     var currentScheme = schemes[i];
-                    // Target Types
-                    var targetTypes = [];
-                    for (var j = 0; j < currentScheme.targetTypes.length; j++) {
-                        targetTypes.push(currentScheme.targetTypes[j].targetType);
-                    }
-                    // Label Sets
-                    var labelSets = [];
-                    for (var j = 0; j < currentScheme.labelSets.length; j++) {
-                        var labelSet = currentScheme.labelSets[j];
-                        var appliesToTargetTypes = [];
-                        for (var k = 0; k < labelSet.appliesToTargetTypes.length; k++) {
-                            var targetType = labelSet.appliesToTargetTypes[k];
-                            appliesToTargetTypes.push(targetType.targetType);
-                        }
-                        var labels = [];
-                        for (var k = 0; k < labelSet.labels.length; k++) {
-                            var label = labelSet.labels[k];
-                            labels.push(label.labelId);
-                        }
-                        var labelSetTemplate = {
-                            name: labelSet.name,
-                            exclusive: labelSet.exclusive,
-                            appliesToTargetTypes: appliesToTargetTypes,
-                            labels: labels
-                        };
-                        labelSets.push(labelSetTemplate);
-                    }
-                    // ToDo: Link Sets
-                    var linkSets = [];
-                    for (var j = 0; j < currentScheme.linkSets.length; j++) {
-                        var linkSet = currentScheme.linkSets[j];
-                        var startType = linkSet.startType.targetType;
-                        var endType = linkSet.endType.targetType;
-                        var linkLabels = [];
-                        for (var k = 0; k < linkSet.linkLabels.length; k++) {
-                            var label = linkSet.linkLabels[k];
-                            linkLabels.push(label.linkLabel);
-                        }
-                        var linkSetTemplate = {
-                            name: linkSet.name,
-                            startType: startType,
-                            endType: endType,
-                            linkLabels: linkLabels
-                        };
-                        linkSets.push(linkSetTemplate);
-                    }
+
                     var template = {
-                        name: currentScheme.name,
-                        targetTypes: targetTypes,
-                        labelSets: labelSets,
-                        linkSets: linkSets
+                        id: currentScheme.id,
+                        name: currentScheme.name
                     };
                     $scope.loadedSchemes.push(template);
                 }
@@ -569,11 +522,94 @@ angular
             });
         };
 
-        $scope.loadPreloadedScheme = function (preloadedScheme) {
-            $scope.name = "Copy of " + preloadedScheme.name;
-            $scope.targets = preloadedScheme.targetTypes;
-            $scope.labelSets = preloadedScheme.labelSets;
-            $scope.linkSets = preloadedScheme.linkSets;
+        $scope.loadPreloadedScheme = function (scheme) {
+
+            if (scheme == null || scheme == undefined) {
+                // Do nothing
+            } else if (scheme.targetTypes == undefined) {
+                $http.get("swan/scheme/byid/" + scheme.id).success(function (response) {
+                    const resScheme = JSOG.parse(JSON.stringify(response.scheme));
+                    scheme = $scope.processScheme(resScheme);
+                    $scope.setSchemeProperties(scheme);
+                    for (var i = 0; i < $scope.loadedSchemes.length; i++) {
+                        if ($scope.loadedSchemes[i].id == scheme.id) {
+                            $scope.loadedSchemes[i] = scheme;
+                            break;
+                        }
+                    }
+                }).error(function (response) {
+                    $rootScope.checkResponseStatusCode(response.status);
+                });
+            } else {
+                $scope.setSchemeProperties(scheme);
+            }
+
+        };
+
+        $scope.processScheme = function (scheme) {
+            // Target Types
+            var targetTypes = [];
+            for (var j = 0; j < scheme.targetTypes.length; j++) {
+                targetTypes.push(scheme.targetTypes[j].targetType);
+            }
+            // Label Sets
+            var labelSets = [];
+            for (var j = 0; j < scheme.labelSets.length; j++) {
+                var labelSet = scheme.labelSets[j];
+                var appliesToTargetTypes = [];
+                for (var k = 0; k < labelSet.appliesToTargetTypes.length; k++) {
+                    var targetType = labelSet.appliesToTargetTypes[k];
+                    appliesToTargetTypes.push(targetType.targetType);
+                }
+                var labels = [];
+                for (var k = 0; k < labelSet.labels.length; k++) {
+                    var label = labelSet.labels[k];
+                    labels.push(label.labelId);
+                }
+                var labelSetTemplate = {
+                    name: labelSet.name,
+                    exclusive: labelSet.exclusive,
+                    appliesToTargetTypes: appliesToTargetTypes,
+                    labels: labels
+                };
+                labelSets.push(labelSetTemplate);
+            }
+            // ToDo: Link Sets
+            var linkSets = [];
+            for (var j = 0; j < scheme.linkSets.length; j++) {
+                var linkSet = scheme.linkSets[j];
+                var startType = linkSet.startType.targetType;
+                var endType = linkSet.endType.targetType;
+                var linkLabels = [];
+                for (var k = 0; k < linkSet.linkLabels.length; k++) {
+                    var label = linkSet.linkLabels[k];
+                    linkLabels.push(label.linkLabel);
+                }
+                var linkSetTemplate = {
+                    name: linkSet.name,
+                    startType: startType,
+                    endType: endType,
+                    linkLabels: linkLabels
+                };
+                linkSets.push(linkSetTemplate);
+            }
+
+            var template = {
+                id: scheme.id,
+                name: scheme.name,
+                targetTypes: targetTypes,
+                labelSets: labelSets,
+                linkSets: linkSets
+            };
+
+            return template;
+        };
+
+        $scope.setSchemeProperties = function (scheme) {
+            $scope.name = "Copy of " + scheme.name;
+            $scope.targets = scheme.targetTypes;
+            $scope.labelSets = scheme.labelSets;
+            $scope.linkSets = scheme.linkSets;
             $scope.loadScheme = true;
         };
 

--- a/src/main/webapp/controllers/schemes/schemeViewModalController.js
+++ b/src/main/webapp/controllers/schemes/schemeViewModalController.js
@@ -25,7 +25,7 @@ angular
             delete scheme.projects;
 
 
-            var targetTypesSimple = new Array();
+            var targetTypesSimple = [];
             for (var j = 0; j < scheme.targetTypes.length; j++) {
                 targetTypesSimple.push(scheme.targetTypes[j].targetType);
             }

--- a/src/main/webapp/controllers/schemes/schemesController.js
+++ b/src/main/webapp/controllers/schemes/schemesController.js
@@ -86,9 +86,7 @@ angular
                     'name': scheme.name,
                     'creator': scheme.creator,
                     'projects': newProjects,
-                    'tableIndex': $scope.schemeCounter,
-                    'labelSetCount': scheme.labelSets.length,
-                    'linkSetCount': scheme.linkSets.length
+                    'tableIndex': $scope.schemeCounter
                 };
                 this.tableSchemes.push(schemePreview);
 
@@ -158,16 +156,34 @@ angular
          * @param {type} name
          */
         $scope.openSchemeViewModal = function (name) {
-            $rootScope.currentScheme = $rootScope.schemesTable[name];
-            var modalInstance = $uibModal.open({
+
+            const uidObject = {
                 animation: $scope.animationsEnabled,
                 templateUrl: 'templates/schemes/schemeViewModal.html',
                 controller: 'schemeViewModalController'
-            });
+            };
+            var modalInstance = null;
 
-            modalInstance.result.then(function (response) {
+            var scheme = $rootScope.schemesTable[name];
+            if (scheme.targetTypes === undefined) {
+                $http.get("swan/scheme/byid/" + scheme.id).success(function (response) {
+                    scheme = response.scheme;
+                    $rootScope.currentScheme = scheme;
+                    modalInstance = $uibModal.open(uidObject);
+                    modalInstance.result.then(function (response) {
 
-            });
+                    });
+                }).error(function (response) {
+                    $rootScope.checkResponseStatusCode(response.status);
+                });
+            } else {
+                $rootScope.currentScheme = scheme;
+                modalInstance = $uibModal.open(uidObject);
+                modalInstance.result.then(function (response) {
+
+                });
+            }
+
             $scope.toggleAnimation = function () {
                 $scope.animationsEnabled = !$scope.animationsEnabled;
             };

--- a/src/main/webapp/modules/app.js
+++ b/src/main/webapp/modules/app.js
@@ -20,12 +20,12 @@ function Config($routeProvider) {
     $routeProvider
         .when('/', {
             templateUrl: 'templates/dashboard.html',
-            controller: 'profileController',
+            controller: 'rootController',
             controllerAs: 'dashboard'
         })
         .when('/dashboard', {
             templateUrl: 'templates/dashboard.html',
-            controller: 'profileController',
+            controller: 'rootController',
             controllerAs: 'dashboard'
         })
         .when('/projects', {

--- a/src/main/webapp/other/annotationStructures.js
+++ b/src/main/webapp/other/annotationStructures.js
@@ -80,6 +80,9 @@ function AnnotationObject(id, type, labels, text) {
     //Sets a label for this object. If this object already has this label, the label
     //is removed; added otherwise
     this.setLabel = function (labelSet, label) {
+        if (labelSet == undefined || label == undefined) {
+            throw "annotationStructure: labelSet or label undefined";
+        }
         var set = this.selectableLabels[labelSet.id];
 
         //Check if this object can be labeled with the set

--- a/src/main/webapp/services/dataServices.js
+++ b/src/main/webapp/services/dataServices.js
@@ -1,11 +1,17 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
 'use strict';
 
+// TODO this is a mess
 angular.module('app')
         .factory("getAnnotationService", function ($http) {
             return  {
                 getAnnotations: function (uId, docId) {
 
-                    // IDEA: Return http without then. Controller handeles then. http://stackoverflow.com/questions/16227644/angularjs-factory-http-service
+                    // IDEA: Return http without then. Controller handles then. http://stackoverflow.com/questions/16227644/angularjs-factory-http-service
                     // Async
 //                    var httpCallback = $http.get("swan/annotations/" + uId + "/" + docId);
 //                    return httpCallback;
@@ -92,8 +98,7 @@ angular.module('app')
 
                 }
             }
-        }
-        )
+        })
         .factory('linkService', function ($http) {
             return  {
                 getLinks: function (uId, docId) {
@@ -113,7 +118,7 @@ angular.module('app')
             }
         })
         .factory('schemeService', function ($http) {
-            return  {
+            return {
                 getScheme: function (docId) {
                     // Async
 //                    $http.get("swan/scheme/" + docId).then(function (response) {
@@ -127,14 +132,25 @@ angular.module('app')
                     xmlHttp.send(null);
                     var schemeJSON = JSOG.parse(xmlHttp.responseText).scheme;
                     return schemeJSON;
-
                 }
             }
-        }).factory('projectService', function ($window, $http) {
-    return  {
-        getScheme: function (docId) {
-            var httpProjects = $http.get("swan/project/byuser/" + $window.sessionStorage.uId);
-            return httpProjects;
-        }
-    }
-});
+        })
+        .factory('schemeByIdService', function ($http) {
+            return {
+                getScheme: function (schemeId) {
+                    var xmlHttp = new XMLHttpRequest();
+                    xmlHttp.open("GET", "swan/scheme/byid/" + schemeId, false); // false for synchronous request
+                    xmlHttp.send(null);
+                    var schemeJSON = JSOG.parse(xmlHttp.responseText).scheme;
+                    return schemeJSON;
+                }
+            }
+        })
+        .factory('projectService', function ($window, $http) {
+            return {
+                getScheme: function (docId) {
+                    var httpProjects = $http.get("swan/project/byuser/" + $window.sessionStorage.uId);
+                    return httpProjects;
+                }
+            }
+        });


### PR DESCRIPTION
The entity mapping and queries were improved so that the db requests
are significantly faster and do not create unnecessary queries.
Almost all FetchTypes were set to LAZY and native queries were
rewritten in JPQL named queries. Query hints were added to prevent
unnecessary queries.
rootController was set for the dashboard because the profileController
requested unnecessarily timelogging.
