### PR TITLE
DA-175: Fix backend tests

### DIFF
--- a/src/main/java/de/unisaarland/discanno/export/ExportUtil.java
+++ b/src/main/java/de/unisaarland/discanno/export/ExportUtil.java
@@ -73,7 +73,7 @@ public class ExportUtil {
      */
     public File getExportDataXmi(Project proj) {
         try {
-            File file = new File("discanno_" + proj.getName() + ".zip");
+            File file = new File("swan_" + proj.getName() + ".zip");
             FileOutputStream fos = new FileOutputStream(file);
             BufferedOutputStream bos = new BufferedOutputStream(fos);
             ZipOutputStream zos = new ZipOutputStream(bos);
@@ -207,7 +207,7 @@ public class ExportUtil {
     public File getExportData(Project proj) {
 
         try {
-            File file = new File("discanno_" + proj.getName() + ".zip");
+            File file = new File("swan_" + proj.getName() + ".zip");
             FileOutputStream fos = new FileOutputStream(file);
             BufferedOutputStream bos = new BufferedOutputStream(fos);
             ZipOutputStream zos = new ZipOutputStream(bos);

--- a/src/main/java/de/unisaarland/discanno/rest/services/v1/ProjectFacadeREST.java
+++ b/src/main/java/de/unisaarland/discanno/rest/services/v1/ProjectFacadeREST.java
@@ -91,6 +91,8 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
             return Response.status(Response.Status.FORBIDDEN).build();
         } catch (CreateException e) {
             return Response.status(Response.Status.BAD_REQUEST).build();
+        } catch (NoResultException e) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
         }
 
     }

--- a/src/test/java/de/unisaarland/discanno/test/AnnotationFacadeRESTTest.java
+++ b/src/test/java/de/unisaarland/discanno/test/AnnotationFacadeRESTTest.java
@@ -51,7 +51,7 @@ public class AnnotationFacadeRESTTest extends BaseTest {
     public void setupForAnnotations() throws CloneNotSupportedException {
         Users admin = TestDataProvider.getAdmin();
         admin.setSession(BaseTest.SESSION_STR);
-        em.persist(admin);
+        persistAndFlush(admin);
         this.user = admin;
         
         Scheme scheme = TestDataProvider.getScheme1();

--- a/src/test/java/de/unisaarland/discanno/test/ProjectsTest.java
+++ b/src/test/java/de/unisaarland/discanno/test/ProjectsTest.java
@@ -42,29 +42,23 @@ public class ProjectsTest extends BaseTest {
         super.configureService(service);
     }
     
-    // TODO fix this
-    // Tests have been disabled due to time reasons because the 
-    // @GeneratedValue(strategy = GenerationType.AUTO) in BaseEntity
-    // has been changed to GenerationType.IDENTITY. Persisting does not create
-    // an id while persisting
-    
-//    @Test
+    @Test
     public void testScenario1() throws CloneNotSupportedException, CreateException {
         
         // Create scheme
         Scheme scheme = TestDataProvider.getScheme1();
         service.process(scheme);
-        em.persist(scheme);
-        
+        persistAndFlush(scheme);
+
         // Create user
         Users user = TestDataProvider.getAdmin();
-        em.persist(user);
+        persistAndFlush(user);
         
         // Create project and set scheme
         Project project = TestDataProvider.getProject1();
         project.getScheme().setId(scheme.getId());
         service.process(project);
-        em.persist(project);
+        persistAndFlush(project);
         
         Users retUser = em.find(Users.class, user.getId());
         assertNotNull(retUser);
@@ -88,7 +82,7 @@ public class ProjectsTest extends BaseTest {
         Document doc = TestDataProvider.getDocument1();
         doc.setProject(project);
         service.process(doc);
-        em.persist(doc);
+        persistAndFlush(doc);
         
         Document retDoc = em.find(Document.class, doc.getId());
         assertNotNull(retDoc);
@@ -130,7 +124,7 @@ public class ProjectsTest extends BaseTest {
         anno.setUser(user);
         anno.setDocument(doc);
         service.process(anno);
-        em.persist(anno);
+        persistAndFlush(anno);
         
         Annotation retAnno = em.find(Annotation.class, anno.getId());
         assertNotNull(retAnno);
@@ -161,7 +155,7 @@ public class ProjectsTest extends BaseTest {
             Label labelBroken = TestDataProvider.getLabel1();
             service.addLabelToAnnotation(retAnno.getId(), labelBroken);
             fail("No IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
+        } catch (CreateException e) {
             assertTrue(e.getMessage()
                     .equals("Service: Adding Label to Annotation failed"));
         }
@@ -175,7 +169,7 @@ public class ProjectsTest extends BaseTest {
         anno.setUser(user);
         anno.setDocument(doc);
         service.process(anno);
-        em.persist(anno);
+        persistAndFlush(anno);
         
         Annotation retAnno = em.find(Annotation.class, anno.getId());
         assertNotNull(retAnno);
@@ -212,7 +206,7 @@ public class ProjectsTest extends BaseTest {
             anno.setUser(user);
             anno.setDocument(doc);
             service.process(anno);
-            em.persist(anno);
+            persistAndFlush(anno);
         }
         
         List<Annotation> retAnnos = findAll(Annotation.class);
@@ -228,7 +222,7 @@ public class ProjectsTest extends BaseTest {
         link.setUser(user);
 
         service.process(link);
-        em.persist(link);
+        persistAndFlush(link);
         
         Link retLink = em.find(Link.class, link.getId());
         assertNotNull(retLink);
@@ -256,9 +250,9 @@ public class ProjectsTest extends BaseTest {
             LinkLabel labelBroken = TestDataProvider.getLinkLabel1();
             service.addLinkLabelToLink(retLink.getId(), labelBroken);
             fail("No IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
+        } catch (CreateException e) {
             assertTrue(e.getMessage()
-                    .equals("Service: Adding LinkLabel to Link failed"));
+                    .equals("Service: Adding LinkLabel to Link failed."));
         }
 
     }

--- a/src/test/java/de/unisaarland/discanno/test/SchemeTest.java
+++ b/src/test/java/de/unisaarland/discanno/test/SchemeTest.java
@@ -32,19 +32,14 @@ public class SchemeTest extends BaseTest {
     public void configService() {
         super.configureService(service);
     }
+
     
-    // TODO fix this
-    // Tests have been disabled due to time reasons because the 
-    // @GeneratedValue(strategy = GenerationType.AUTO) in BaseEntity
-    // has been changed to GenerationType.IDENTITY. Persisting does not create
-    // an id while persisting
-    
-//    @Test
+    @Test
     public void testCreate() throws CreateException {
         
         Scheme scheme = TestDataProvider.getScheme1();
         service.process(scheme);
-        em.persist(scheme);
+        persistAndFlush(scheme);
         
         Scheme retScheme = em.find(Scheme.class, scheme.getId());
         


### PR DESCRIPTION
Previously, backend tests weren't running anymore because the strategy
for generating PK's hat been changed from GenerationType.AUTO to
GenerationType.IDENTITY. With identity sequencing id's are not
assigned before flush() or commit() is called, so a call of em.flush()
was added after each call of persist.
Additionally, some tests weren't running because they were trying to catch
the wrong Exception types.
