### PR TITLE
DA-200: Optimize removing projects

### DIFF
--- a/src/main/java/de/unisaarland/discanno/dao/AnnotationDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/AnnotationDAO.java
@@ -49,7 +49,7 @@ public class AnnotationDAO extends BaseEntityDAO<Annotation> {
         }
     }
     
-    public List<Annotation> getAllAnnotationsByUserIdDocId(Long userId, Long docId) {
+    public List<Annotation> getAllAnnotationsByUserIdDocId(final Long userId, final Long docId) {
         Map<String, Long> map = new HashMap<>();
         map.put(Annotation.PARAM_USER, userId);
         map.put(Annotation.PARAM_DOCUMENT, docId);
@@ -68,18 +68,16 @@ public class AnnotationDAO extends BaseEntityDAO<Annotation> {
                     Annotation.QUERY_FIND_BY_USER,
                     Collections.singletonMap(Annotation.PARAM_USER, entity));
     }
-    
+
     /**
-     * Returns all annotations by a specific document id. Just for remove
-     * purposes.
-     * 
+     * Removes all annotations belonging to a document.
+     *
      * @param entity
-     * @return 
      */
-    public List<Annotation> getAllAnnotationsByDocId(Document entity) {
-        return executeQuery(
-                    Annotation.QUERY_FIND_BY_DOCUMENT,
-                    Collections.singletonMap(Annotation.PARAM_DOCUMENT, entity));
+    public void removeAllAnnotationsByDocId(Document entity) {
+        executeUpdate(
+                Annotation.QUERY_DELETE_BY_DOCUMENT,
+                Collections.singletonMap(Annotation.PARAM_DOCUMENT, entity));
     }
     
 }

--- a/src/main/java/de/unisaarland/discanno/dao/BaseEntityDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/BaseEntityDAO.java
@@ -61,13 +61,23 @@ public abstract class BaseEntityDAO<Entity> extends AbstractDAO {
             return firstResult(entities);
         }
     }
-    
-    protected List<Entity> executeQuery(String queryName, Map<String, ?> parameters) {
+
+    private TypedQuery<Entity> prepareQuery(String queryName, Map<String, ?> parameters) {
         TypedQuery<Entity> query = createNamedQuery(queryName, entityClass);
         for (Map.Entry<String, ?> entry : parameters.entrySet()) {
             query.setParameter(entry.getKey(), entry.getValue());
         }
+        return query;
+    }
+    
+    protected List<Entity> executeQuery(String queryName, Map<String, ?> parameters) {
+        TypedQuery<Entity> query = prepareQuery(queryName, parameters);
         return query.getResultList();
+    }
+
+    protected int executeUpdate(String queryName, Map<String, ?> parameters) {
+        TypedQuery<Entity> query = prepareQuery(queryName, parameters);
+        return query.executeUpdate();
     }
     
 }

--- a/src/main/java/de/unisaarland/discanno/dao/LinkDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/LinkDAO.java
@@ -6,6 +6,8 @@
 package de.unisaarland.discanno.dao;
 
 import de.unisaarland.discanno.entities.Link;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,17 +35,23 @@ public class LinkDAO extends BaseEntityDAO<Link> {
      * @param annoId
      * @return 
      */
-    public List<Link> getAllLinksByAnnoId(Long annoId) {
+    public List<Link> getAllLinksByAnnoId(final Long annoId) {
         Map<String, Long> params = new HashMap<>();
         params.put(Link.PARAM_ANNOTATION1, annoId);
         params.put(Link.PARAM_ANNOTATION2, annoId);
         return executeQuery(Link.QUERY_FIND_BY_ANNO1_AND_ANNO2, params);
     }
+
+    public void removeAllLinksByDocId(final Long docId) {
+        executeUpdate(
+                Link.QUERY_DELETE_BY_DOC_ID,
+                Collections.singletonMap(Link.PARAM_DOC_ID, docId));
+    }
     
-    public List<Link> getAllLinksByUserIdDocId(Long userId, Long docId) {
+    public List<Link> getAllLinksByUserIdDocId(final Long userId, final Long docId) {
         Map<String, Long> params = new HashMap<>();
-        params.put(Link.PARAM_DOC, docId);
-        params.put(Link.PARAM_USER, userId);
+        params.put(Link.PARAM_DOC_ID, docId);
+        params.put(Link.PARAM_USER_ID, userId);
         return executeQuery(Link.QUERY_FIND_BY_DOC_AND_USER, params);
     }
     

--- a/src/main/java/de/unisaarland/discanno/dao/ProjectDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/ProjectDAO.java
@@ -59,4 +59,11 @@ public class ProjectDAO extends BaseEntityDAO<Project> {
                 Collections.singletonMap(Project.PARAM_USER, user));
     }
 
+    public Project getProjectToDelete(final Long projId) {
+        return firstResult(
+                    executeQuery(
+                        Project.QUERY_FIND_PROJECT_TO_DELETE,
+                        Collections.singletonMap(Project.PARAM_ID, projId)));
+    }
+
 }

--- a/src/main/java/de/unisaarland/discanno/dao/StateDAO.java
+++ b/src/main/java/de/unisaarland/discanno/dao/StateDAO.java
@@ -41,11 +41,17 @@ public class StateDAO extends BaseEntityDAO<State> {
                     Collections.singletonMap(State.PARAM_USER, user));
     }
     
-    public State getStateByDocIdUserId(Long docId, Long userId, boolean nullOptional) {
+    public State getStateByDocIdUserId(final Long docId, final Long userId, boolean nullOptional) {
         Map<String, Long> params = new HashMap<>();
         params.put(State.PARAM_DOC, docId);
         params.put(State.PARAM_USER, userId);
         return executeQuery(State.QUERY_FIND_BY_DOC_AND_USER, params, nullOptional);
+    }
+
+    public void removeAllStatesByDocId(final Long docId) {
+        executeUpdate(
+                State.QUERY_DELETE_BY_DOCUMENT,
+                Collections.singletonMap(State.PARAM_DOC, docId));
     }
     
 }

--- a/src/main/java/de/unisaarland/discanno/entities/Annotation.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Annotation.java
@@ -7,29 +7,15 @@ package de.unisaarland.discanno.entities;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import de.unisaarland.discanno.rest.view.View;
+
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * The Entity Annotation holds all the information about an annotation
- * in the text:
- * - the user who annotated the text
- * - the section that is annotated
- * - the labels which belong to the annotation
  *
  * @author Timo Guehring
  */
@@ -38,28 +24,28 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Table(uniqueConstraints={@UniqueConstraint(columnNames = { "user_fk", "document_fk", "targetType_fk", "StartS", "EndS" })})
 @NamedQueries({
     @NamedQuery(
-        name = Annotation.QUERY_FIND_BY_DOCUMENT,
-        query = "SELECT a " +
+        name = Annotation.QUERY_DELETE_BY_DOCUMENT,
+        query = "DELETE " +
                 "FROM Annotation a " +
-                "WHERE a.document = :" + Annotation.PARAM_DOCUMENT),
+                "WHERE a.document = :" + Annotation.PARAM_DOCUMENT,
+        hints = {
+        }
+    ),
     @NamedQuery(
         name = Annotation.QUERY_FIND_BY_USER,
         query = "SELECT a " +
                 "FROM Annotation a " +
-                "WHERE a.user = :" + Annotation.PARAM_USER),
+                "WHERE a.user = :" + Annotation.PARAM_USER
+    ),
     @NamedQuery(
         name = Annotation.QUERY_FIND_BY_USER_AND_DOC,
         query = "SELECT a1 " +
                 "FROM Annotation a1 " +
-                "WHERE a1.user.id = :" + Annotation.PARAM_USER + " AND a1.document.id = :" + Annotation.PARAM_DOCUMENT)
+                "WHERE a1.user.id = :" + Annotation.PARAM_USER + " AND a1.document.id = :" + Annotation.PARAM_DOCUMENT
+    )
 })
 public class Annotation extends BaseEntity {
-    
-    /**
-     * Named query identifier for "find by document".
-     */
-    public static final String QUERY_FIND_BY_DOCUMENT = "Annotation.QUERY_FIND_BY_DOCUMENT";
-    
+
     /**
      * Named query identifier for "find by user".
      */
@@ -69,7 +55,12 @@ public class Annotation extends BaseEntity {
      * Named query identifier for "find by user and doc".
      */
     public static final String QUERY_FIND_BY_USER_AND_DOC = "Annotation.QUERY_FIND_BY_USER_AND_DOC";
-    
+
+    /**
+     * Named query identifier for "delete by document"
+     */
+    public static final String QUERY_DELETE_BY_DOCUMENT = "Annotation.QUERY_DELETE_BY_DOCUMENT";
+
     /**
      * Query parameter constant for the attribute "document".
      */
@@ -82,7 +73,8 @@ public class Annotation extends BaseEntity {
     
     @JsonView({ View.Annotations.class, View.Links.class })
     @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-                fetch = FetchType.EAGER, optional = true)
+                fetch = FetchType.EAGER,
+                optional = true)
     @JoinColumn(name="user_fk")
     private Users user;
     

--- a/src/main/java/de/unisaarland/discanno/entities/Document.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Document.java
@@ -78,7 +78,7 @@ public class Document extends BaseEntity {
      * They do not have an user id.
      */
     @JsonView({ View.Documents.class })
-    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE },
+    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
                 fetch = FetchType.LAZY)
     @JoinTable(
         name="DOCUMENT_DEFAULTANNOTATIONS",

--- a/src/main/java/de/unisaarland/discanno/entities/LabelLabelSetMap.java
+++ b/src/main/java/de/unisaarland/discanno/entities/LabelLabelSetMap.java
@@ -7,13 +7,7 @@ package de.unisaarland.discanno.entities;
 
 import java.util.HashSet;
 import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 /**
  * The LabelLabelSetMap maps Labels to its corresponding LabelSets. This is used

--- a/src/main/java/de/unisaarland/discanno/entities/LabelSet.java
+++ b/src/main/java/de/unisaarland/discanno/entities/LabelSet.java
@@ -50,7 +50,8 @@ public class LabelSet extends BaseEntity {
      * Contains the targettypes which can be annotated with this label.
      */
     @JsonView({ View.Scheme.class })
-    @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.LAZY)
+    @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+                fetch = FetchType.LAZY)
     @JoinTable(
         name="TARGETTYPE_LABELSET",
         joinColumns={@JoinColumn(name="LABEL_SET_ID", referencedColumnName="id")},

--- a/src/main/java/de/unisaarland/discanno/entities/Link.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Link.java
@@ -7,17 +7,10 @@ package de.unisaarland.discanno.entities;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import de.unisaarland.discanno.rest.view.View;
+
 import java.util.HashSet;
 import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 
 /**
  *
@@ -26,11 +19,24 @@ import javax.persistence.OneToMany;
 @Entity
 @NamedQueries({
     @NamedQuery(
-            name = Link.QUERY_FIND_BY_DOC_AND_USER,
-            query = "SELECT l FROM Link l WHERE l.document.id = :" + Link.PARAM_DOC + " AND l.user.id = :" + Link.PARAM_USER),
+        name = Link.QUERY_FIND_BY_DOC_AND_USER,
+        query = "SELECT l " +
+                "FROM Link l " +
+                "WHERE l.document.id = :" + Link.PARAM_DOC_ID + " AND l.user.id = :" + Link.PARAM_USER_ID
+    ),
     @NamedQuery(
-            name = Link.QUERY_FIND_BY_ANNO1_AND_ANNO2,
-            query = "SELECT l FROM Link l WHERE l.annotation1.id = :" + Link.PARAM_ANNOTATION1 + " OR l.annotation2.id = :" + Link.PARAM_ANNOTATION2)
+        name = Link.QUERY_FIND_BY_ANNO1_AND_ANNO2,
+        query = "SELECT l " +
+                "FROM Link l " +
+                "WHERE l.annotation1.id = :" + Link.PARAM_ANNOTATION1 + " " +
+                    "OR l.annotation2.id = :" + Link.PARAM_ANNOTATION2
+    ),
+    @NamedQuery(
+        name = Link.QUERY_DELETE_BY_DOC_ID,
+        query = "DELETE " +
+                "FROM Link l " +
+                "WHERE l.document.id = :" + Link.PARAM_DOC_ID
+    )
 })
 public class Link extends BaseEntity {
     
@@ -43,16 +49,21 @@ public class Link extends BaseEntity {
      * Named query identifier for "find by user".
      */
     public static final String QUERY_FIND_BY_ANNO1_AND_ANNO2 = "Link.QUERY_FIND_BY_ANNO1_AND_ANNO2";
+
+    /**
+     * Named query identifier for "delete by doc id"
+     */
+    public static final String QUERY_DELETE_BY_DOC_ID = "Link.QUERY_DELETE_BY_DOC_ID";
     
     /**
-     * Query parameter constant for the attribute "user".
+     * Query parameter constant for the attribute "user.id".
      */
-    public static final String PARAM_USER = "user";
+    public static final String PARAM_USER_ID = "user_id";
     
     /**
-     * Query parameter constant for the attribute "document".
+     * Query parameter constant for the attribute "document.id".
      */
-    public static final String PARAM_DOC = "doc";
+    public static final String PARAM_DOC_ID = "doc_id";
     
     /**
      * Query parameter constant for the attribute "annotation1".

--- a/src/main/java/de/unisaarland/discanno/entities/Project.java
+++ b/src/main/java/de/unisaarland/discanno/entities/Project.java
@@ -63,6 +63,18 @@ import javax.persistence.*;
         hints = {
             @QueryHint(name = QueryHints.LEFT_FETCH, value = "p.documents.states")
         }
+    ),
+    @NamedQuery(
+        name = Project.QUERY_FIND_PROJECT_TO_DELETE,
+        query = "SELECT p " +
+                "FROM Project p " +
+                "LEFT JOIN FETCH p.documents " +
+                "LEFT JOIN FETCH p.scheme " +
+                "WHERE p.id = :" + Project.PARAM_ID,
+        hints = {
+            @QueryHint(name = QueryHints.LEFT_FETCH, value = "p.documents.states"),
+            @QueryHint(name = QueryHints.LEFT_FETCH, value = "p.documents.defaultAnnotations")
+        }
     )
 })
 public class Project extends BaseEntity {
@@ -83,9 +95,19 @@ public class Project extends BaseEntity {
     public static final String QUERY_FIND_PROJECTS_BY_PROJECT_MANAGER = "Project.QUERY_FIND_PROJECTS_BY_PROJECT_MANAGER";
 
     /**
+     * Named query identifier for "find project to delete"
+     */
+    public static final String QUERY_FIND_PROJECT_TO_DELETE = "Project.QUERY_FIND_PROJECT_TO_DELETE";
+
+    /**
      * Query parameter constant for the attribute "user".
      */
     public static final String PARAM_USER = "user";
+
+    /**
+     * Query parameter constant for the attribute "id"
+     */
+    public static final String PARAM_ID = "id";
 
 
     @JsonView({ View.Projects.class, View.Documents.class })

--- a/src/main/java/de/unisaarland/discanno/entities/State.java
+++ b/src/main/java/de/unisaarland/discanno/entities/State.java
@@ -30,12 +30,20 @@ import javax.persistence.UniqueConstraint;
         name = State.QUERY_FIND_BY_DOC_AND_USER,
         query = "SELECT s " +
                 "FROM State s " +
-                "WHERE s.document.id = :" + State.PARAM_DOC + " AND s.user.id = :" + State.PARAM_USER),
+                "WHERE s.document.id = :" + State.PARAM_DOC + " AND s.user.id = :" + State.PARAM_USER
+    ),
     @NamedQuery(
         name = State.QUERY_FIND_BY_USER,
         query = "SELECT s " +
                 "FROM State s " +
-                "WHERE s.user = :" + State.PARAM_USER)
+                "WHERE s.user = :" + State.PARAM_USER
+    ),
+    @NamedQuery(
+        name = State.QUERY_DELETE_BY_DOCUMENT,
+        query = "DELETE " +
+                "FROM State s " +
+                "WHERE s.document.id = :" + State.PARAM_DOC
+    )
 })
 public class State extends BaseEntity {
 
@@ -48,7 +56,12 @@ public class State extends BaseEntity {
      * Named query identifier for "find by user".
      */
     public static final String QUERY_FIND_BY_USER = "State.QUERY_FIND_BY_USER";
-    
+
+    /**
+     * Named query identifier for "delete by document".
+     */
+    public static final String QUERY_DELETE_BY_DOCUMENT = "State.QUERY_DELETE_BY_DOCUMENT";
+
     /**
      * Query parameter constant for the attribute "user".
      */

--- a/src/main/java/de/unisaarland/discanno/entities/TargetType.java
+++ b/src/main/java/de/unisaarland/discanno/entities/TargetType.java
@@ -47,6 +47,7 @@ public class TargetType implements Serializable {
                 fetch = FetchType.LAZY)
     private List<LabelSet> labelSets = new ArrayList<>();
 
+
     public String getTargetType() {
         return targetType;
     }

--- a/src/main/java/de/unisaarland/discanno/rest/services/v1/ProjectFacadeREST.java
+++ b/src/main/java/de/unisaarland/discanno/rest/services/v1/ProjectFacadeREST.java
@@ -85,7 +85,7 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
 
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
-            service.removeProject(projectDAO.find(id, false));
+            service.removeProject(id);
             return Response.status(Response.Status.OK).build();
         } catch (SecurityException e) {
             return Response.status(Response.Status.FORBIDDEN).build();

--- a/src/main/webapp/controllers/projects/projectDeleteModalController.js
+++ b/src/main/webapp/controllers/projects/projectDeleteModalController.js
@@ -18,21 +18,15 @@ angular
 
         $scope.deleteProject = function (projId) {
             $http.delete("swan/project/" + projId).success(function (response) {
-
+                for (var i = 0; i < $rootScope.tableProjects.length; i++) {
+                    if ($rootScope.tableProjects[i].id === projId) {
+                        $rootScope.tableProjects.splice(i, 1);
+                        break;
+                    }
+                }
             }).error(function (response) {
                 $rootScope.checkResponseStatusCode(response.status);
             });
-
-            // TODO this should be inside the success function
-            // but currently the response takes too much time
-            // first this issue has to be fixed:
-            // https://github.com/annefried/discanno/issues/190
-            for (var i = 0; i < $rootScope.tableProjects.length; i++) {
-                if ($rootScope.tableProjects[i].id === projId) {
-                    $rootScope.tableProjects.splice(i, 1);
-                    break;
-                }
-            }
 
             $uibModalInstance.close();
         };

--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -17,7 +17,7 @@ angular
             
             /**
              * Called at the end of Controller construction.
-             * Initializes fields with data from Server.
+             * Initializes fields with data from backend.
              */
             $scope.init = function () {
                 $scope.loaded = false;
@@ -48,7 +48,7 @@ angular
             });
 
             /**
-             * Used for the toggle + Button.
+             * Used for the toggle '+'-Button.
              * @param {type} id the id of the Project to toggle.
              * @returns {String} css class.
              */
@@ -109,7 +109,7 @@ angular
             };
 
             /**
-             * Load Schemes from Database
+             * Load Schemes from backend
              */
             $scope.loadSchemes = function () {
                 var httpSchemes = $http.get("swan/scheme/schemes").success(function (response) {


### PR DESCRIPTION
Removing a project which is related to removing documents and annotations etc.
was very inefficient. It is still not very fast with a lot of dependencies but
better. Sometimes a OutOfMemory exception occured. This should not happen
anymore evoked by deleting a project.
Instead of SELECT queries and then deleting the entites the queries were
replaced by direct DELETE queries.
