### PR TITLE
DA-219: Allow jumps to links

### DIFF
--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -1754,9 +1754,15 @@ angular
                 };
 
                 $scope.jumpToSelection = function(jumpFunction) {
+                    var jumpTarget;
+                    if ($scope.selection.type === "Link") {
+                        jumpTarget = $scope.selection.source;
+                    } else {
+                        jumpTarget = $scope.selection;
+                    }
                     for (var annoID in formAnnotations) {
                         var annotation = formAnnotations[annoID];
-                        if (annotation.annotation === $scope.selection) {
+                        if (annotation.annotation === jumpTarget) {
                             // Use first word in Anno, since first box might not have a coordinate
                             const firstWord = annotation.annotationBoxes[0].formWords[0];
                             if (firstWord.x === 0 && firstWord.y === 0) {


### PR DESCRIPTION
Previously, clicking a link in the graph would not cause the text view
to jump to that link. Now, the text view jumps to the source node of the
link.
