### PR TITLE
DA-226: Prevent frontend from adding an annotation with the same star…

### DIFF
--- a/src/main/java/de/unisaarland/discanno/rest/services/v1/AnnotationFacadeREST.java
+++ b/src/main/java/de/unisaarland/discanno/rest/services/v1/AnnotationFacadeREST.java
@@ -160,7 +160,7 @@ public class AnnotationFacadeREST extends AbstractFacade<Annotation> {
     }
     
     @POST
-    @Path("/changett/{annoId}")
+    @Path("/changest/{annoId}")
     @Produces({MediaType.APPLICATION_JSON})
     public Response changeSpanTypeREST(@PathParam("annoId") Long annoId, SpanType spanType) {
         

--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -31,7 +31,7 @@ angular
                 removedSpanType: "=",
                 setSelection: "&",
                 setTemp: "&",
-                getAnnotation: "&",
+                getAnnotationById: "&",
                 addLink: "&",
                 linkable: "&",
                 clearSelection: "&",

--- a/src/main/webapp/directives/d3Options.js
+++ b/src/main/webapp/directives/d3Options.js
@@ -22,8 +22,7 @@ angular
                 removeAnnotation: "&",
                 removeTarget: "&",
                 removeLink: "&",
-                setType: "&",
-                setTypeAndAdd: "&",
+                setSelectedSpanTypeAndAdd: "&",
                 setAnnotationNotSure: "&"
             },
             link: function ($scope, iElement) {
@@ -144,24 +143,25 @@ angular
                     }
                 };
 
-                $scope.setTypeHotkeys = function (e) {
-                    var a = [];
+                /**
+                 * Sets the next span type of the currently selected node.
+                 * Used for HotKeys.
+                 *
+                 * @param index
+                 */
+                $scope.setNextSpanType = function (index) {
+                    var spanTypeMap = [];
                     var i = 0;
                     for (var id in $scope.spanTypes) {
-                        var type = $scope.spanTypes[id];
-                        a[i] = type;
+                        spanTypeMap[i] = $scope.spanTypes[id];
                         i++;
                     }
-                    var type = a[e];
-                    if (type !== undefined) {
-                        $scope.setTypeAndAdd({item: type});
-                        $scope.setType({item: type});
-                    } else {
+                    var spanType = spanTypeMap[index];
+                    if (spanType === undefined) {
                         $scope.index = 0;
-                        var type = a[0];
-                        $scope.setTypeAndAdd({item: type});
-                        $scope.setType({item: type});
+                        spanType = spanTypeMap[0];
                     }
+                    $scope.setSelectedSpanTypeAndAdd({item: spanType});
                 };
 
                 $scope.setLabelHotkeys = function (e) {
@@ -190,7 +190,7 @@ angular
                                 description: 'Select next span type',
                                 callback: function () {
                                     $scope.index++;
-                                    $scope.setTypeHotkeys($scope.index);
+                                    $scope.setNextSpanType($scope.index);
                                 }
                             })
                             .add({
@@ -259,7 +259,7 @@ angular
                             })
                             .on("click", function (d) {
                                 $scope.$apply(function () {
-                                    $scope.setTypeAndAdd({item: d.value});
+                                    $scope.setSelectedSpanTypeAndAdd({item: d.value});
                                 });
                             });
                     parent.selectAll("button").each(function () {

--- a/src/main/webapp/other/annotationStructures.js
+++ b/src/main/webapp/other/annotationStructures.js
@@ -232,7 +232,6 @@ function Annotation(color, id, sType) {
             this.words = words;
             this.text = this.text.substring(word.text.length, this.text.length);
         }
-        console.log(this)
         return word;
     };
 

--- a/src/main/webapp/templates/annotation.html
+++ b/src/main/webapp/templates/annotation.html
@@ -68,7 +68,7 @@ and open the template in the editor.
                                                on-user-change="annotation.onUserChange()"
                                                size-increased="annotation.sizeIncreased"
                                                data="annotation.annotationText"
-                                               annotations="annotation.annotationData"
+                                               annotations="annotation.annotationIdMap"
                                                targets="annotation.targets"
                                                links="annotation.annotationLinks"
                                                selection="annotation.selectedNode"
@@ -82,7 +82,7 @@ and open the template in the editor.
                                                set-selection="annotation.setSelected(item)"
                                                add-annotation="annotation.addAnnotation(item, words)"
                                                set-temp="annotation.setTemporaryAnnotation(item)" 
-                                               get-annotation="annotation.getAnnotation(item)"
+                                               get-annotation="annotation.getAnnotationById(item)"
                                                add-link="annotation.addLink(source, target)"
                                                linkable="annotation.linkable(source, target)"
                                                clear-selection="d3Anno.clearSelection()"
@@ -131,7 +131,7 @@ and open the template in the editor.
                                 <div>
                                     <div ng-controller="d3TimelineController as timeline">
                                         <d3-timeline
-                                            annotations="annotation.annotationData"
+                                            annotations="annotation.annotationIdMap"
                                             annotation-links="annotation.annotationLinks"
                                             selection="annotation.selectedNode"
                                             added-annotation="annotation.lastAdded"
@@ -156,7 +156,7 @@ and open the template in the editor.
                                                  id="anno-graph">
                                 <div>
                                     <div ng-controller="d3GraphController as graph">
-                                        <d3-graph annotations="annotation.annotationData"
+                                        <d3-graph annotations="annotation.annotationIdMap"
                                                   annotation-links="annotation.annotationLinks"
                                                   selection="annotation.selectedNode"
                                                   added-annotation="annotation.lastAdded"
@@ -185,8 +185,7 @@ and open the template in the editor.
                                             remove-annotation="annotation.removeAnnotation(item)"
                                             remove-target="annotation.removeTarget(item)"
                                             remove-link="annotation.removeLink(item)"
-                                            set-type="annotation.setSelectedSpanType(item)"
-                                            set-type-and-add="annotation.setSelectedSpanTypeAndAdd(item)"
+                                            set-selected-span-type-and-add="annotation.setSelectedSpanTypeAndAdd(item)"
                                             set-annotation-not-sure="annotation.setAnnotationNotSure(item,bool)">
                                 </d3-options>
                             </div>


### PR DESCRIPTION
…t, end and span type

It is not possible anymore to add or change an annotation so that there
are two annotations with the same start, end and span type properties.
Additionally some parts of the annotationController and d3Annotation
were refactored.
