### PR TITLE
DA-244: Refactor frontend and create structure for cross doc linking

### DIFF
--- a/src/main/webapp/css/annotation.css
+++ b/src/main/webapp/css/annotation.css
@@ -2,10 +2,9 @@
     margin-left: 0.5em;
 }
 
-.scroll-pane
-{
+.scroll-pane {
     overflow: scroll !important;
-    height:auto;
+    height: auto;
 /*    max-height: 400px;*/
 }
 
@@ -41,6 +40,12 @@
 
 .annotationtext {
     margin-top: 1em;
+}
+
+/* Split view for cross document linking */
+.annotationtextSplitted {
+    /* height: 40%;
+    max-height: 100px; */
 }
 
 .annotationbox {
@@ -116,11 +121,11 @@
 }
 
 .panel-body {
-    padding:5px;
+    padding: 5px;
 }
 
 .col-md-7 {
-    padding:5px;
+    padding: 5px;
 }
 
 .btn {

--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -1163,16 +1163,16 @@ angular
 
                     currentLine = firstLine;
                     //Draw the actual text by iterating through the lines
-                    var dat = []
+                    var dat = [];
                     var pos = pre;
                     for (var j = firstLine; j <= lastLine; j++) {
                     	//Safety measure:
                     	//Stop drawing if a non-existing line is reached
-                    	 if (formText[j] === undefined){
-                    	   break;
+                    	 if (formText[j] === undefined) {
+                             break;
                     	 }
                     	// Add empty line in front of first line
-                    	if(j == 0){
+                    	if(j == 0) {
                     		dat.push(undefined)
                     	}
                     	// Add line to draw
@@ -1190,9 +1190,9 @@ angular
                             .append(function (d) {
                                 var text = document.createElementNS("http://www.w3.org/2000/svg", "text");
                                 // Handle empty lines
-                                if(d === undefined){
+                                if (d === undefined) {
                                 	text.innerHTML = ''
-                                }else{
+                                } else {
                                 	text.innerHTML = d.word.text;
                                 	d.element = text;
                                 }
@@ -1221,21 +1221,21 @@ angular
                                 pos += spacing;
                                 d.x = pos;
                                 // load previously computed lengths
-                                d.width = $scope.widthMap[d.word.text]
+                                d.width = $scope.widthMap[d.word.text];
                                 pos += d.width;
 
                                 return ~~d.x;
                             })
                             .attr("y", function (d, i) {
                             	// Handle empty lines
-                            	if (d === undefined){
+                            	if (d === undefined) {
                             		currentHeight += lineHeight;
                             	} else {
                                     //Set the height of the current word to the height of
                                     //the previous word if we are still in the same line
-                                    if (d.lY === currentLine){
+                                    if (d.lY === currentLine) {
                                         d.y = currentHeight;
-                                    }else {
+                                    } else {
                                     	//Set the height of the first word of a new line
                                     	//to the previous height + the height of that line
                                         d.y = currentHeight + d.height;
@@ -1245,7 +1245,7 @@ angular
                             	}
                                 return ~~currentHeight;
                             })
-                            .classed("annotationtext", function(d){
+                            .classed("annotationtext", function(d) {
                             	// Handle empty lines
                             	return d !== undefined;
                             })

--- a/src/main/webapp/templates/annocrossdoc.html
+++ b/src/main/webapp/templates/annocrossdoc.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<link href="css/annotation.css" rel="stylesheet">
+<link href="css/graph.css" rel="stylesheet">
+<link href="css/annotationoptions.css" rel="stylesheet">
+
+<div>
+    <div>
+
+        <div>
+            <div class="col-md-7"
+
+                 ng-controller="d3AnnotationController as d3Anno"
+                 ng-mouseup="d3Anno.UpdateSelectionText()">
+
+                <div class="annotationtitle filename" id="1-anno-tool">
+                    <label class="headerinfo">Project: </label>
+                    <label class="infotitle">{{d3Anno.project}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                    <label class="headerinfo">Document: </label>
+                    <label class="infotitle">{{d3Anno.title}}</label>
+                    <label ng-hide="isUnprivileged == 'false'">&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                    <div style="display: inline-block;"
+                         ng-controller="annotationController as annoCon"
+                         ng-hide="isUnprivileged == 'false'">
+                        <input type="checkbox"
+                               value=""
+                               style="margin: 0px;"
+                               ng-model="completed"
+                               ng-click="annoCon.setDocCompleted()">
+                        <label>Completed&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                        <div class="row" style="display: inline-block;">
+                            <button class="btn btn-default"
+                                    style="text-align: center; width: 80px; line-height: 18px;"
+                                    ng-click="annoCon.nextDoc(-1)">
+                                <span class="glyphicon glyphicon-chevron-left pull-left"
+                                      style="display: inline-block;"></span> Previous
+                            </button>
+                            <button class="btn btn-default"
+                                    style="text-align:center; width:80px; line-height: 18px;"
+                                    ng-click="annoCon.nextDoc(1)">
+                                <span class="glyphicon glyphicon-chevron-right pull-right"
+                                      style="display: inline-block;"></span> Next
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <hr class="featurette-divider">
+
+                <div class="annotationfield annotationtextSplitted">
+                    <uib-alert ng-repeat="alert in alerts"
+                               type="{{alert.type}}"
+                               close="closeAlert($index)"
+                               dismiss-on-timeout="10000">
+                        {{alert.msg}}
+                    </uib-alert>
+
+                    <uib-accordion close-others="false">
+                        <uib-accordion-group is-disabled="true" is-open="true">
+                            <uib-accordion-heading>
+                                <div class="unselectable" id="anno-text1">Text1</div>
+                            </uib-accordion-heading>
+
+                            <div>
+                                <d3-annotation class="d3Anno"
+                                               on-user-change="annotation.onUserChange()"
+                                               size-increased="annotation.sizeIncreased"
+                                               data="annotation.annotationText"
+                                               annotations="annotation.annotationIdMap"
+                                               targets="annotation.targets"
+                                               links="annotation.annotationLinks"
+                                               selection="annotation.selectedNode"
+                                               temp-anno="annotation.tempAnno"
+                                               start-selection="d3Anno.startSelection"
+                                               end-selection="d3Anno.endSelection"
+                                               last-added="annotation.lastAdded"
+                                               last-removed="annotation.lastRemoved"
+                                               last-set="annotation.lastSet"
+                                               removed-span-type="annotation.lastRemovedSpanType"
+                                               set-selection="annotation.setSelected(item)"
+                                               add-annotation="annotation.addAnnotation(item, words)"
+                                               set-temp="annotation.setTemporaryAnnotation(item)"
+                                               get-annotation="annotation.getAnnotationById(item)"
+                                               add-link="annotation.addLink(source, target)"
+                                               linkable="annotation.linkable(source, target)"
+                                               clear-selection="d3Anno.clearSelection()"
+                                               increase-selected-anno-size-right="annotation.increaseSelectedAnnoSizeRight()"
+                                               increase-selected-anno-size-left="annotation.increaseSelectedAnnoSizeLeft()"
+                                               decrease-selected-anno-size-right="annotation.decreaseSelectedAnnoSizeRight()"
+                                               decrease-selected-anno-size-left="annotation.decreaseSelectedAnnoSizeLeft()"
+                                               reset-size-increased="annotation.resetSizeIncreased()">
+                                </d3-annotation>
+                            </div>
+
+                        </uib-accordion-group>
+                    </uib-accordion>
+
+                    <div class="col-md-5 rightwindow">
+
+                        <uib-accordion close-others="false">
+                            <uib-accordion-group is-disabled="true" is-open="true">
+                                <uib-accordion-heading>
+                                    <div class="unselectable" id="anno-text2">Text2</div>
+                                </uib-accordion-heading>
+
+                                <div>
+                                    <d3-annotation class="d3Anno"
+                                                   on-user-change="annotation.onUserChange()"
+                                                   size-increased="annotation.sizeIncreased"
+                                                   data="annotation.annotationText"
+                                                   annotations="annotation.annotationIdMap"
+                                                   targets="annotation.targets"
+                                                   links="annotation.annotationLinks"
+                                                   selection="annotation.selectedNode"
+                                                   temp-anno="annotation.tempAnno"
+                                                   start-selection="d3Anno.startSelection"
+                                                   end-selection="d3Anno.endSelection"
+                                                   last-added="annotation.lastAdded"
+                                                   last-removed="annotation.lastRemoved"
+                                                   last-set="annotation.lastSet"
+                                                   removed-span-type="annotation.lastRemovedSpanType"
+                                                   set-selection="annotation.setSelected(item)"
+                                                   add-annotation="annotation.addAnnotation(item, words)"
+                                                   set-temp="annotation.setTemporaryAnnotation(item)"
+                                                   get-annotation="annotation.getAnnotationById(item)"
+                                                   add-link="annotation.addLink(source, target)"
+                                                   linkable="annotation.linkable(source, target)"
+                                                   clear-selection="d3Anno.clearSelection()"
+                                                   increase-selected-anno-size-right="annotation.increaseSelectedAnnoSizeRight()"
+                                                   increase-selected-anno-size-left="annotation.increaseSelectedAnnoSizeLeft()"
+                                                   decrease-selected-anno-size-right="annotation.decreaseSelectedAnnoSizeRight()"
+                                                   decrease-selected-anno-size-left="annotation.decreaseSelectedAnnoSizeLeft()"
+                                                   reset-size-increased="annotation.resetSizeIncreased()">
+                                    </d3-annotation>
+                                </div>
+
+                            </uib-accordion-group>
+                        </uib-accordion>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+
+        <div>
+            <div ng-class="GraphAccordion">
+                <div class="scroll-pane">
+                    <uib-accordion close-others="false">
+                        <!-- ng-show or ng-hide does not work on uib-accordion-group
+                            therefore create a div containing the uib-accordion-group -->
+                        <div ng-hide="isUnprivileged == 'true'">
+                            <uib-accordion-group heading="Users" is-open="true" is-disabled="status.isFirstDisabled" class="unselectable">
+                                <div ng-controller="annotationController as annoCon">
+                                    <form id="users">
+                                        <div ng-repeat="u in users">
+                                            <label ng-show="u.role == 'annotator'">
+                                                <input type="radio" name="users" value="{{u.id}}" ng-model="shownUserList[u.id]"
+                                                       ng-click="changeCallbackCont()">
+                                                {{u.prename + " " + u.lastname}}
+                                            </label><br>
+                                        </div>
+                                    </form>
+                                </div>
+                            </uib-accordion-group>
+                        </div>
+
+                        <!-- Annotation options -->
+                        <div ng-include src="'templates/viselements/annotationoptions.html'"></div>
+
+                        <!-- Navigation to other documents -->
+                        <div ng-include src="'templates/viselements/projectnavigation.html'"></div>
+
+                        <!-- Shortcuts -->
+                        <div ng-include src="'templates/viselements/shortcuts.html'"></div>
+
+                    </uib-accordion>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+</div>

--- a/src/main/webapp/templates/annotation.html
+++ b/src/main/webapp/templates/annotation.html
@@ -49,61 +49,24 @@ and open the template in the editor.
 
                 <hr class="featurette-divider">
 
-                <div class="annotationfield" >
+                <div class="annotationfield">
                     <uib-alert ng-repeat="alert in alerts"
                                type="{{alert.type}}"
                                close="closeAlert($index)"
                                dismiss-on-timeout="10000">
                         {{alert.msg}}
                     </uib-alert>
+
                     <uib-accordion close-others="false">
-
-                        <uib-accordion-group is-disabled="true" is-open="true">
-                            <uib-accordion-heading>
-                                <div class="unselectable" id="anno-text">Text</div>
-                            </uib-accordion-heading>
-
-                            <div>
-                                <d3-annotation class="d3Anno"
-                                               on-user-change="annotation.onUserChange()"
-                                               size-increased="annotation.sizeIncreased"
-                                               data="annotation.annotationText"
-                                               annotations="annotation.annotationIdMap"
-                                               targets="annotation.targets"
-                                               links="annotation.annotationLinks"
-                                               selection="annotation.selectedNode"
-                                               temp-anno="annotation.tempAnno"
-                                               start-selection="d3Anno.startSelection"
-                                               end-selection="d3Anno.endSelection"
-                                               last-added="annotation.lastAdded"
-                                               last-removed="annotation.lastRemoved"
-                                               last-set="annotation.lastSet"
-                                               removed-span-type="annotation.lastRemovedSpanType"
-                                               set-selection="annotation.setSelected(item)"
-                                               add-annotation="annotation.addAnnotation(item, words)"
-                                               set-temp="annotation.setTemporaryAnnotation(item)" 
-                                               get-annotation="annotation.getAnnotationById(item)"
-                                               add-link="annotation.addLink(source, target)"
-                                               linkable="annotation.linkable(source, target)"
-                                               clear-selection="d3Anno.clearSelection()"
-                                               increase-selected-anno-size-right="annotation.increaseSelectedAnnoSizeRight()"
-                                               increase-selected-anno-size-left="annotation.increaseSelectedAnnoSizeLeft()"
-                                               decrease-selected-anno-size-right="annotation.decreaseSelectedAnnoSizeRight()"
-                                               decrease-selected-anno-size-left="annotation.decreaseSelectedAnnoSizeLeft()"
-                                               reset-size-increased="annotation.resetSizeIncreased()">
-                                </d3-annotation>
-                            </div>
-
-                        </uib-accordion-group>
+                        <div ng-include src="'templates/viselements/text.html'"></div>
                     </uib-accordion>
-
                 </div>
             </div>
         </div>
 
         <div class="col-md-5 rightwindow">
             <div ng-class="GraphAccordion">
-                <div class="scroll-pane ">
+                <div class="scroll-pane">
                     <uib-accordion close-others="false">
                         <!-- ng-show or ng-hide does not work on uib-accordion-group
                             therefore create a div containing the uib-accordion-group -->
@@ -125,162 +88,22 @@ and open the template in the editor.
 
                         <!-- Timeline -->
                         <div ng-if="timeline.show">
-                            <uib-accordion-group heading="Timeline"
-                                                 is-open="timeline.isOpen"
-                                                 class="unselectable">
-                                <div>
-                                    <div ng-controller="d3TimelineController as timeline">
-                                        <d3-timeline
-                                            annotations="annotation.annotationIdMap"
-                                            annotation-links="annotation.annotationLinks"
-                                            selection="annotation.selectedNode"
-                                            added-annotation="annotation.lastAdded"
-                                            removed-annotation="annotation.lastRemoved"
-                                            added-link="annotation.lastAddedLink"
-                                            removed-link="annotation.lastRemovedLink"
-                                            last-set="annotation.lastSet"
-                                            change-link-label="annotation.changeLinkLabel"
-                                            last-targeted="annotation.lastTargeted"
-                                            set-selection="annotation.setSelected(item)">
-                                        </d3-timeline>
-                                    </div>
-                                </div>
-                            </uib-accordion-group>
+                            <div ng-include src="'templates/viselements/timeline.html'"></div>
                         </div>
 
                         <!-- Graph -->
                         <div ng-if="graph.show">
-                            <uib-accordion-group heading="Graph"
-                                                 is-open="graph.isOpen"
-                                                 class="unselectable"
-                                                 id="anno-graph">
-                                <div>
-                                    <div ng-controller="d3GraphController as graph">
-                                        <d3-graph annotations="annotation.annotationIdMap"
-                                                  annotation-links="annotation.annotationLinks"
-                                                  selection="annotation.selectedNode"
-                                                  added-annotation="annotation.lastAdded"
-                                                  removed-annotation="annotation.lastRemoved"
-                                                  removed-link="annotation.lastRemovedLink"
-                                                  added-link="annotation.lastAddedLink"
-                                                  last-set="annotation.lastSet"
-                                                  last-targeted="annotation.lastTargeted"
-                                                  set-selection="annotation.setSelected(item)">
-                                        </d3-graph>
-                                    </div>
-                                </div>
-                            </uib-accordion-group>
+                            <div ng-include src="'templates/viselements/graph.html'"></div>
                         </div>
 
                         <!-- Annotation options -->
-                        <uib-accordion-group heading="Annotations" is-disabled="false" is-open="true" class="unselectable" id="anno-options">
-                            <div ng-controller="d3OptionsController as options">
-                                <d3-options data="annotation.annotationText"
-                                            selection="annotation.selectedNode"
-                                            labels="annotation.labelTable"
-                                            span-types="annotation.spanTypes"
-                                            temp-anno="annotation.tempAnno"
-                                            set-selection="annotation.setSelected(item)"
-                                            set-label="annotation.setSelectedLabel(label, set)"
-                                            remove-annotation="annotation.removeAnnotation(item)"
-                                            remove-target="annotation.removeTarget(item)"
-                                            remove-link="annotation.removeLink(item)"
-                                            set-selected-span-type-and-add="annotation.setSelectedSpanTypeAndAdd(item)"
-                                            set-annotation-not-sure="annotation.setAnnotationNotSure(item,bool)">
-                                </d3-options>
-                            </div>
-                        </uib-accordion-group>
+                        <div ng-include src="'templates/viselements/annotationoptions.html'"></div>
 
                         <!-- Navigation to other documents -->
-                        <uib-accordion-group
-                            heading="Project navigation"
-                            is-disabled="false"
-                            is-open="false"
-                            class="unselectable"
-                            id="anno-navigation">
-                            
-                            <div ng-repeat="proj in this.tableProjects">
-                                <label>{{proj.name}}</label>
-                                <table class="table">
-                                    <tr ng-repeat="doc in proj.documents">
-                                        <td>
-                                            <a ng-if="doc.id != currDoc.id"
-                                               ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)">
-                                                {{doc.name}}
-                                            </a>
-                                            <a ng-if="doc.id == currDoc.id"
-                                               ng-href
-                                               ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)"
-                                               style="color: gray">
-                                                {{doc.name}}
-                                            </a>
-                                        </td>
-                                        <td>
-                                            <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
-                                                class="glyphicon glyphicon-ok">
-                                            </span>
-                                        </td>
-                                    </tr>                                                         
-                                </table>
-                            </div>
-                        </uib-accordion-group>
+                        <div ng-include src="'templates/viselements/projectnavigation.html'"></div>
 
                         <!-- Shortcuts -->
-                        <uib-accordion-group heading="Help" is-disabled="false" is-open="false" class="unselectable" id="anno-shortcuts">
-
-                            <p><strong>Create annotations:</strong> select a span
-                                of text or double-click on a word. Then select a Type for the annotation.
-                            </p>
-                            <p><strong>Adding labels:</strong> when you select an annotation,
-                                appropriate label sets will be displayed in the 'Annotations' box.</p>
-                            <p><strong>Adding links:</strong> select the annotation at which your link will
-                                start, and drag your mouse away from the annotation. All possible
-                                end notes (according to the scheme) will be highlighted. Drop your mouse
-                                at one of them and release the mouse button.</p>
-                            <p><strong>Viewing links:</strong> click on an annotation to view the links
-                                that start or end at this annotation.
-                            <p><strong>Selections:</strong> click anywhere on an empty space in the Text box
-                                to unselect the currently selected annotation or link.</p>
-                            <p><strong>Navigation:</strong> you can use the Graph visualization to navigate
-                                through your text document by clicking on the nodes in the graph.
-                                You can also go to another document by using the Project navigation box.</p>
-
-                            <p><strong>Shortcuts:</strong> there are many cool shortcuts using
-                                keys that will make your life much easier. Check them out! <br/><br/>
-
-                                <strong>When a span annotation is selected, changing annotations:</strong>
-                            <table class="table">
-                                <tr>
-                                    <td><kbd><kbd>a</kbd></kbd></td>
-                                    <td>add the token on the left to the current annotation</td>
-                                </tr>
-                                <tr>
-                                    <td><kbd><kbd>s</kbd></kbd></td>
-                                    <td>remove the left-most token from the current span annotation</td>
-                                </tr>
-                                <tr>
-                                    <td><kbd><kbd>d</kbd></kbd></td>
-                                    <td>remove the right-most token from the current span annotation</td>
-                                </tr>  
-                                <tr>
-                                    <td><kbd><kbd>f</kbd></kbd></td>
-                                    <td>add the token on the right to the current annotation</td>
-                                </tr>
-                            </table>
-
-                            <strong>When a span annotation is selected, changing the selection:</strong>
-                            <table class="table">
-                                <tr>
-                                    <td><kbd>left</kbd> / <kbd>right</kbd></td>
-                                    <td>jump between annotations</td>
-                                </tr>
-                                <!--tr>
-                                    <td><kbd><kbd>?</kbd></kbd></td>
-                                    <td>Show all shortcuts (Shift + ?)</td>
-                                </tr-->
-                                
-                            </table>
-                        </uib-accordion-group>
+                        <div ng-include src="'templates/viselements/shortcuts.html'"></div>
 
                     </uib-accordion>
                 </div>

--- a/src/main/webapp/templates/viselements/annotationoptions.html
+++ b/src/main/webapp/templates/viselements/annotationoptions.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<uib-accordion-group heading="Annotations" is-disabled="false" is-open="true" class="unselectable" id="anno-options">
+    <div ng-controller="d3OptionsController as options">
+        <d3-options data="annotation.annotationText"
+                    selection="annotation.selectedNode"
+                    labels="annotation.labelTable"
+                    span-types="annotation.spanTypes"
+                    temp-anno="annotation.tempAnno"
+                    set-selection="annotation.setSelected(item)"
+                    set-label="annotation.setSelectedLabel(label, set)"
+                    remove-annotation="annotation.removeAnnotation(item)"
+                    remove-target="annotation.removeTarget(item)"
+                    remove-link="annotation.removeLink(item)"
+                    set-selected-span-type-and-add="annotation.setSelectedSpanTypeAndAdd(item)"
+                    set-annotation-not-sure="annotation.setAnnotationNotSure(item,bool)">
+        </d3-options>
+    </div>
+</uib-accordion-group>

--- a/src/main/webapp/templates/viselements/graph.html
+++ b/src/main/webapp/templates/viselements/graph.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<uib-accordion-group heading="Graph"
+                     is-open="graph.isOpen"
+                     class="unselectable"
+                     id="anno-graph">
+    <div>
+        <div ng-controller="d3GraphController as graph">
+            <d3-graph annotations="annotation.annotationIdMap"
+                      annotation-links="annotation.annotationLinks"
+                      selection="annotation.selectedNode"
+                      added-annotation="annotation.lastAdded"
+                      removed-annotation="annotation.lastRemoved"
+                      removed-link="annotation.lastRemovedLink"
+                      added-link="annotation.lastAddedLink"
+                      last-set="annotation.lastSet"
+                      last-targeted="annotation.lastTargeted"
+                      set-selection="annotation.setSelected(item)">
+            </d3-graph>
+        </div>
+    </div>
+</uib-accordion-group>

--- a/src/main/webapp/templates/viselements/projectnavigation.html
+++ b/src/main/webapp/templates/viselements/projectnavigation.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<uib-accordion-group
+        heading="Project navigation"
+        is-disabled="false"
+        is-open="false"
+        class="unselectable"
+        id="anno-navigation">
+
+    <div ng-repeat="proj in this.tableProjects">
+        <label>{{proj.name}}</label>
+        <table class="table">
+            <tr ng-repeat="doc in proj.documents">
+                <td>
+                    <a ng-if="doc.id != currDoc.id"
+                       ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)">
+                        {{doc.name}}
+                    </a>
+                    <a ng-if="doc.id == currDoc.id"
+                       ng-href
+                       ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)"
+                       style="color: gray">
+                        {{doc.name}}
+                    </a>
+                </td>
+                <td>
+                    <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
+                          class="glyphicon glyphicon-ok">
+                    </span>
+                </td>
+            </tr>
+        </table>
+    </div>
+</uib-accordion-group>

--- a/src/main/webapp/templates/viselements/shortcuts.html
+++ b/src/main/webapp/templates/viselements/shortcuts.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<uib-accordion-group heading="Help" is-disabled="false" is-open="false" class="unselectable" id="anno-shortcuts">
+
+    <p><strong>Create annotations:</strong> select a span
+        of text or double-click on a word. Then select a Type for the annotation.
+    </p>
+    <p><strong>Adding labels:</strong> when you select an annotation,
+        appropriate label sets will be displayed in the 'Annotations' box.</p>
+    <p><strong>Adding links:</strong> select the annotation at which your link will
+        start, and drag your mouse away from the annotation. All possible
+        end notes (according to the scheme) will be highlighted. Drop your mouse
+        at one of them and release the mouse button.</p>
+    <p><strong>Viewing links:</strong> click on an annotation to view the links
+        that start or end at this annotation.
+    <p><strong>Selections:</strong> click anywhere on an empty space in the Text box
+        to unselect the currently selected annotation or link.</p>
+    <p><strong>Navigation:</strong> you can use the Graph visualization to navigate
+        through your text document by clicking on the nodes in the graph.
+        You can also go to another document by using the Project navigation box.</p>
+
+    <p><strong>Shortcuts:</strong> there are many cool shortcuts using
+        keys that will make your life much easier. Check them out! <br/><br/>
+
+        <strong>When a span annotation is selected, changing annotations:</strong>
+    <table class="table">
+        <tr>
+            <td><kbd><kbd>a</kbd></kbd></td>
+            <td>add the token on the left to the current annotation</td>
+        </tr>
+        <tr>
+            <td><kbd><kbd>s</kbd></kbd></td>
+            <td>remove the left-most token from the current span annotation</td>
+        </tr>
+        <tr>
+            <td><kbd><kbd>d</kbd></kbd></td>
+            <td>remove the right-most token from the current span annotation</td>
+        </tr>
+        <tr>
+            <td><kbd><kbd>f</kbd></kbd></td>
+            <td>add the token on the right to the current annotation</td>
+        </tr>
+    </table>
+
+    <strong>When a span annotation is selected, changing the selection:</strong>
+    <table class="table">
+        <tr>
+            <td><kbd>left</kbd> / <kbd>right</kbd></td>
+            <td>jump between annotations</td>
+        </tr>
+        <!--tr>
+            <td><kbd><kbd>?</kbd></kbd></td>
+            <td>Show all shortcuts (Shift + ?)</td>
+        </tr-->
+
+    </table>
+</uib-accordion-group>

--- a/src/main/webapp/templates/viselements/text.html
+++ b/src/main/webapp/templates/viselements/text.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<uib-accordion-group is-disabled="true" is-open="true">
+    <uib-accordion-heading>
+        <div class="unselectable" id="anno-text">Text</div>
+    </uib-accordion-heading>
+
+    <div>
+        <d3-annotation class="d3Anno"
+                       on-user-change="annotation.onUserChange()"
+                       size-increased="annotation.sizeIncreased"
+                       data="annotation.annotationText"
+                       annotations="annotation.annotationIdMap"
+                       targets="annotation.targets"
+                       links="annotation.annotationLinks"
+                       selection="annotation.selectedNode"
+                       temp-anno="annotation.tempAnno"
+                       start-selection="d3Anno.startSelection"
+                       end-selection="d3Anno.endSelection"
+                       last-added="annotation.lastAdded"
+                       last-removed="annotation.lastRemoved"
+                       last-set="annotation.lastSet"
+                       removed-span-type="annotation.lastRemovedSpanType"
+                       set-selection="annotation.setSelected(item)"
+                       add-annotation="annotation.addAnnotation(item, words)"
+                       set-temp="annotation.setTemporaryAnnotation(item)"
+                       get-annotation="annotation.getAnnotationById(item)"
+                       add-link="annotation.addLink(source, target)"
+                       linkable="annotation.linkable(source, target)"
+                       clear-selection="d3Anno.clearSelection()"
+                       increase-selected-anno-size-right="annotation.increaseSelectedAnnoSizeRight()"
+                       increase-selected-anno-size-left="annotation.increaseSelectedAnnoSizeLeft()"
+                       decrease-selected-anno-size-right="annotation.decreaseSelectedAnnoSizeRight()"
+                       decrease-selected-anno-size-left="annotation.decreaseSelectedAnnoSizeLeft()"
+                       reset-size-increased="annotation.resetSizeIncreased()">
+        </d3-annotation>
+    </div>
+
+</uib-accordion-group>

--- a/src/main/webapp/templates/viselements/timeline.html
+++ b/src/main/webapp/templates/viselements/timeline.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<uib-accordion-group heading="Timeline"
+                     is-open="timeline.isOpen"
+                     class="unselectable">
+    <div>
+        <div ng-controller="d3TimelineController as timeline">
+            <d3-timeline
+                    annotations="annotation.annotationIdMap"
+                    annotation-links="annotation.annotationLinks"
+                    selection="annotation.selectedNode"
+                    added-annotation="annotation.lastAdded"
+                    removed-annotation="annotation.lastRemoved"
+                    added-link="annotation.lastAddedLink"
+                    removed-link="annotation.lastRemovedLink"
+                    last-set="annotation.lastSet"
+                    change-link-label="annotation.changeLinkLabel"
+                    last-targeted="annotation.lastTargeted"
+                    set-selection="annotation.setSelected(item)">
+            </d3-timeline>
+        </div>
+    </div>
+</uib-accordion-group>


### PR DESCRIPTION
A more modularized structure was applied so that it can be
better reused for future tasks including cross doc linking e.g.
the graph and timeline views were separated in extra html files
so that they can be included in other html files.
