### PR TITLE
DA-231: Fix rendering of links to/from off-screen annotations

### DIFF
--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -1494,7 +1494,33 @@ angular
                                     const formTarget = formAnnotations[target.id];
                                     const sourceBox = formSource.annotationBoxes[formSource.annotationBoxes.length - 1];
                                     const targetBox = formTarget.annotationBoxes[0];
-                                    //Determine the edges of the path of the link
+
+                                    // Determine the edges of the path of the link;
+                                    // if the position of one of the boxes is not yet known, estimate it
+                                    // by using the first word of the corresponding annotation
+                                    if (sourceBox.x === undefined && sourceBox.y === undefined && sourceBox.width === undefined) {
+                                        $scope.drawText(sourceBox.formWords[0].lY-10,sourceBox.formWords[0].lY+10);
+                                        $scope.drawText(minJ, maxJ);
+                                        return lineFunction(
+                                            [{"x": ~~sourceBox.formWords[0].x + sourceBox.formWords[0].width, "y": ~~sourceBox.formWords[0].y + 0.5 * wordHeight / 3},
+                                                {"x": ~~((sourceBox.formWords[0].x + sourceBox.formWords[0].width * 1.3)), "y": ~~sourceBox.formWords[0].y + 0.5 * wordHeight / 3},
+                                                {"x": ~~((sourceBox.formWords[0].x + sourceBox.formWords[0].width * 1.3)), "y": ~~targetBox.y - 1.5 * wordHeight / 3},
+                                                {"x": ~~targetBox.x + 0.5 * targetBox.width, "y": ~~targetBox.y - 1.5 * wordHeight / 3},
+                                                {"x": ~~targetBox.x + 0.5 * targetBox.width, "y": ~~targetBox.y}]
+                                        );
+                                    }
+                                    if (targetBox.x === undefined && targetBox.y === undefined && targetBox.width === undefined) {
+                                        $scope.drawText(targetBox.formWords[0].lY-10,targetBox.formWords[0].lY+10);
+                                        $scope.drawText(minJ, maxJ);
+                                        return lineFunction(
+                                            [{"x": ~~sourceBox.x + sourceBox.width, "y": ~~sourceBox.y + 0.5 * wordHeight / 3},
+                                                {"x": ~~((sourceBox.x + sourceBox.width * 1.3)), "y": ~~sourceBox.y + 0.5 * wordHeight / 3},
+                                                {"x": ~~((sourceBox.x + sourceBox.width * 1.3)), "y": ~~targetBox.formWords[0].y - 1.5 * wordHeight / 3},
+                                                {"x": ~~targetBox.formWords[0].x + 0.5 * targetBox.formWords[0].width, "y": ~~targetBox.formWords[0].y - 1.5 * wordHeight / 3},
+                                                {"x": ~~targetBox.formWords[0].x + 0.5 * targetBox.formWords[0].width, "y": ~~targetBox.formWords[0].y}]
+                                        );
+                                    }
+                                    // If both boxes are well-defined, return path between them
                                     const lineData = [{"x": ~~sourceBox.x + sourceBox.width, "y": ~~sourceBox.y + 0.5 * wordHeight / 3},
                                         {"x": ~~((sourceBox.x + sourceBox.width * 1.3)), "y": ~~sourceBox.y + 0.5 * wordHeight / 3},
                                         {"x": ~~((sourceBox.x + sourceBox.width * 1.3)), "y": ~~targetBox.y - 1.5 * wordHeight / 3},


### PR DESCRIPTION
Previously, links which had an off-screen annotations on one end were not
displayed correctly (either in the wrong direction or not at all). This is
fixed by estimating the positions of unrendered annotations by the position
of their first word so that the line can be drawn correctly.

NOTE: This patch fixes issues #231 and #232, as they are closely related.
