### PR TITLE
DA-149: Make completion checkbox fixed

### DIFF
--- a/src/main/webapp/css/annotation.css
+++ b/src/main/webapp/css/annotation.css
@@ -1,4 +1,6 @@
 .annotationfield {
+    position: static;
+    z-index: -1;
     margin-left: 0.5em;
 }
 
@@ -8,9 +10,18 @@
 /*    max-height: 400px;*/
 }
 
-.annotationtitle {
-    margin-left: 0.5em;
-    margin-top: 4.5em;
+.top-bar {
+    position: fixed;
+    z-index: 99;
+    width: 100%;
+    height: 6.5em;
+    background-color: #f5f5f5 !important;
+}
+
+.container-title {
+    margin-left: 1.7em;
+    margin-right: 2.7em;
+    margin-top: 4.3em;
 }
 
 .accordionfield {
@@ -35,7 +46,7 @@
 
 .infotitle {
     font-size: 100%;
-    color: gray;
+    color: dimgrey;
 }
 
 .annotationtext {
@@ -67,7 +78,7 @@
     position: fixed;
     padding: 1em;
     left: 79%;
-    top: 7.7em;
+    top: 7.3em;
     transform: translateX(-50%);
 }
 
@@ -115,16 +126,12 @@
    margin: 3px 0.5ex;
 }
 
-.col-md-4 {
-    padding:0;
-    padding-right: 10px;
-}
-
 .panel-body {
     padding: 5px;
 }
 
 .col-md-7 {
+    top: 7.7em;
     padding: 5px;
 }
 

--- a/src/main/webapp/templates/annotation.html
+++ b/src/main/webapp/templates/annotation.html
@@ -10,44 +10,47 @@ and open the template in the editor.
 
 <div>
     <div>
-
-        <div>
-
-            <div class="col-md-7" ng-controller="d3AnnotationController as d3Anno" ng-mouseup="d3Anno.UpdateSelectionText()">
-
-                <div class="annotationtitle filename" id="1-anno-tool">
-                    <label class="headerinfo">Project: </label>
-                    <label class="infotitle">{{d3Anno.project}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
-                    <label class="headerinfo">Document: </label>
-                    <label class="infotitle">{{d3Anno.title}}</label>
-                    <label ng-hide="isUnprivileged == 'false'">&nbsp;&nbsp;&nbsp;&nbsp;</label>
-                    <div style="display: inline-block;"
-                        ng-controller="annotationController as annoCon"
-                        ng-hide="isUnprivileged == 'false'">
-                        <input type="checkbox"
-                               value=""
-                               style="margin: 0px;"
-                               ng-model="completed"
-                               ng-click="annoCon.setDocCompleted()">
-                        <label>Completed&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-                        <div class="row" style="display: inline-block;">
-                            <button class="btn btn-default"
-                                    style="text-align:center; width:80px; line-height: 18px;"
-                                    ng-click="annoCon.nextDoc(-1)">
-                                <span class="glyphicon glyphicon-chevron-left pull-left"
-                                      style="display: inline-block;"></span> Previous
-                            </button>
-                            <button class="btn btn-default"
-                                    style="text-align:center; width:80px; line-height: 18px;"
-                                    ng-click="annoCon.nextDoc(1)">
-                                <span class="glyphicon glyphicon-chevron-right pull-right"
-                                      style="display: inline-block;"></span> Next
-                            </button>
+        <div class="top-bar">
+            <div class="container-title">
+                <div class="row">
+                    <div class="col-md-8" id="1-anno-tool" ng-controller="d3AnnotationController as d3Anno">
+                        <label class="headerinfo">Project: </label>
+                        <label class="infotitle">{{d3Anno.project}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                        <label class="headerinfo">Document: </label>
+                        <label class="infotitle">{{d3Anno.title}}</label>
+                        <label ng-hide="isUnprivileged == 'false'">&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                        <div style="display: inline-block;"
+                             ng-controller="annotationController as annoCon"
+                             ng-hide="isUnprivileged == 'false'" align="right">
+                            <input type="checkbox"
+                                   value=""
+                                   style="margin: 0px;"
+                                   ng-model="completed"
+                                   ng-click="annoCon.setDocCompleted()">
+                            <label>Completed</label>
                         </div>
                     </div>
+                    <div class="col-md-4" ng-controller="annotationController as annoCon"
+                         ng-hide="isUnprivileged == 'false'" align="right">
+                        <button class="btn btn-default"
+                                style="text-align:center; width:100px; line-height: 18px;"
+                                ng-click="annoCon.nextDoc(-1)">
+                                    <span class="glyphicon glyphicon-chevron-left pull-left"
+                                          style="display: inline-block;"></span> Previous
+                        </button>
+                        <button class="btn btn-default"
+                                style="text-align:center; width:100px; line-height: 18px;"
+                                ng-click="annoCon.nextDoc(1)">
+                                    <span class="glyphicon glyphicon-chevron-right pull-right"
+                                          style="display: inline-block;"></span> Next
+                        </button>
+                    </div>
                 </div>
+           </div>
+         </div>
 
-                <hr class="featurette-divider">
+        <div>
+            <div class="col-md-7" ng-controller="d3AnnotationController as d3Anno" ng-mouseup="d3Anno.UpdateSelectionText()">
 
                 <div class="annotationfield">
                     <uib-alert ng-repeat="alert in alerts"


### PR DESCRIPTION
A top bar containing project/document information, the completion checkbox
and previous/next buttons was added to the annotation view,
so annotators don't have to scroll up anymore to mark documents as completed.
