### PR TITLE
DA-262: Fix project name checking as project manager

### DIFF
--- a/src/main/java/de/unisaarland/swan/dao/ProjectDAO.java
+++ b/src/main/java/de/unisaarland/swan/dao/ProjectDAO.java
@@ -13,6 +13,7 @@ import java.util.List;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.persistence.TypedQuery;
 
 /**
  * This DAO (Data Access Object) provides all CRUD operations for projects.
@@ -71,6 +72,11 @@ public class ProjectDAO extends BaseEntityDAO<Project> {
                 executeQuery(
                         Project.QUERY_FIND_PROJECT_TO_ADD_USER,
                         Collections.singletonMap(Project.PARAM_ID, projId)));
+    }
+
+    public List<String> getAllProjectNames() {
+        TypedQuery<String> query = em.createNamedQuery(Project.QUERY_FIND_ALL_PROJECT_NAMES, String.class);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/de/unisaarland/swan/entities/Project.java
+++ b/src/main/java/de/unisaarland/swan/entities/Project.java
@@ -86,6 +86,11 @@ import javax.validation.constraints.NotNull;
         hints = {
             @QueryHint(name = QueryHints.LEFT_FETCH, value = "p.documents.defaultAnnotations")
         }
+    ),
+    @NamedQuery(
+        name = Project.QUERY_FIND_ALL_PROJECT_NAMES,
+        query = "SELECT p.name " +
+                "FROM Project p"
     )
 })
 public class Project extends BaseEntity {
@@ -114,6 +119,11 @@ public class Project extends BaseEntity {
      * Named query identifier for "find project to add user"
      */
     public static final String QUERY_FIND_PROJECT_TO_ADD_USER = "Project.QUERY_FIND_PROJECT_TO_ADD_USER";
+
+    /**
+     * Named query identifier for "find all project names"
+     */
+    public static final String QUERY_FIND_ALL_PROJECT_NAMES = "Project.QUERY_FIND_ALL_PROJECT_NAMES";
 
     /**
      * Query parameter constant for the attribute "user".

--- a/src/main/java/de/unisaarland/swan/rest/services/v1/ProjectFacadeREST.java
+++ b/src/main/java/de/unisaarland/swan/rest/services/v1/ProjectFacadeREST.java
@@ -222,6 +222,35 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
         
     }
+
+    /**
+     * Returns a list of all project names, so the frontend can check on
+     * duplicate names.
+     *
+     * @return
+     */
+    @GET
+    @Path("/names")
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getAllProjectNames() {
+
+        try {
+            LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
+
+            List<String> list = projectDAO.getAllProjectNames();
+
+            return Response.ok(mapper.writer()
+                                        .withRootName("projects")
+                                        .writeValueAsString(list))
+                            .build();
+        } catch (SecurityException e) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        } catch (JsonProcessingException ex) {
+            Logger.getLogger(SchemeFacadeREST.class.getName()).log(Level.SEVERE, null, ex);
+            return Response.serverError().build();
+        }
+
+    }
     
     /**
      * This method returns a zip archive containing all Users annotations project
@@ -237,7 +266,7 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
     public Response exportProjectByProjIdAsZip(@PathParam("projId") Long projId) {
 
         try {
-            LoginUtil.check(usersDAO.checkLogin(getSessionID()));
+            LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
 
             Project proj = (Project) projectDAO.find(projId, false);
             
@@ -273,7 +302,7 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
     public Response exportProjectByProjIdAsXmiZip(@PathParam("projId") Long projId) {
 
         try {
-            LoginUtil.check(usersDAO.checkLogin(getSessionID()));
+            LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
 
             Project proj = (Project) projectDAO.find(projId, false);
             

--- a/src/main/webapp/controllers/projects/projectAddModalController.js
+++ b/src/main/webapp/controllers/projects/projectAddModalController.js
@@ -13,11 +13,20 @@ angular
             // Available tokenization languages
             $scope.lanaguages = [ "Unspecified", "Spanish", "English", "German", "French" ];
             $scope.loadSchemes();
+            $scope.loadNames();
         };
 
         $scope.loadSchemes = function () {
             $http.get("swan/scheme/schemes").success(function (response) {
                 $scope.schemes = JSOG.parse(JSON.stringify(response)).schemes;
+            }).error(function (response) {
+                $rootScope.checkResponseStatusCode(response.status);
+            });
+        };
+
+        $scope.loadNames = function () {
+            $http.get("swan/project/names").success(function (response) {
+                $rootScope.names = JSOG.parse(JSON.stringify(response)).projects;
             }).error(function (response) {
                 $rootScope.checkResponseStatusCode(response.status);
             });
@@ -31,9 +40,8 @@ angular
          */
         $scope.hasError = function (name) {
             if (name) {
-                for (var i = 0; i < $rootScope.tableProjects.length; i++) {
-                    var proj = $rootScope.tableProjects[i];
-                    if (proj.name === name) {
+                for (var i = 0; i < $rootScope.names.length; i++) {
+                    if (name == $rootScope.names[i]) {
                         return true;
                     }
                 }


### PR DESCRIPTION
When creating a new project it was only checked on the projects available
in the own project list. Now a list with all and only names will be
requested to check on this as well as admin, because we might change
the project handling in the future.
