### PR TITLE
DA-276: Fix display error when trying to view text with predefined targets

### DIFF
--- a/src/main/java/de/unisaarland/swan/tokenization/model/Line.java
+++ b/src/main/java/de/unisaarland/swan/tokenization/model/Line.java
@@ -15,19 +15,19 @@ import java.util.List;
  * @author Timo Guehring
  */
 public class Line {
-    
+
     @JsonIgnore
     private int lineLength;
-    
+
     private List<Token> tokens = new ArrayList<>();
 
     @JsonProperty
     public int getLineLength() {
         int length = 0;
         for (Token t : tokens) {
-            length += t.getText().length();
+			length += t.getEnd() - t.getStart();
         }
-        
+
         return length;
     }
 
@@ -38,9 +38,9 @@ public class Line {
     public void setTokens(List<Token> tokens) {
         this.tokens = tokens;
     }
-    
+
     public void addTokens(Token token) {
         this.tokens.add(token);
     }
-    
+
 }


### PR DESCRIPTION
Previously, uploaded text with predefined targets could sometimes not be
displayed. This bug was caused by discrepancies in the byte length of
some tokens vs. their actual number of characters, as well as the Stanford
tokenizer replacing quotation marks with other symbols.
The bug has been fixed by using the pre-computed length of tokens instead
of String.length().
