### PR TITLE
DA-294: Fix missing appliesToSpanTypes attribute

### DIFF
--- a/src/main/java/de/unisaarland/swan/entities/SpanType.java
+++ b/src/main/java/de/unisaarland/swan/entities/SpanType.java
@@ -51,7 +51,7 @@ public class SpanType extends ColorableBaseEntity {
     @JsonIgnore
     @ManyToMany(mappedBy = "appliesToSpanTypes",
                 cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-                fetch = FetchType.LAZY)
+                fetch = FetchType.EAGER)
     private List<LabelSet> labelSets = new ArrayList<>();
 
 


### PR DESCRIPTION
In certain circumstances, the appliesToSpanTypes attribute was empty for Schemes,
even though it had been defined and was present in the database. This resulted
in an inability to choose labels during annotation.
The problem has been fixed by changing the FetchType for the labelSets to EAGER,
which should make sure that all necessary information is fetched in time.
