### PR TITLE
DA-294: Fix missing appliesToSpanTypes attribute

### DIFF
--- a/src/main/java/de/unisaarland/swan/entities/LabelSet.java
+++ b/src/main/java/de/unisaarland/swan/entities/LabelSet.java
@@ -17,8 +17,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * The LabelSet Entity represents a set of labels as defined in a
- * given scheme. 
- * 
+ * given scheme.
+ *
  * The JsonIdentityInfo annotations prevents infinite recursions.
  *
  * @author Timo Guehring
@@ -52,13 +52,13 @@ public class LabelSet extends ColorableBaseEntity {
      */
     @JsonView({ View.SchemeByDocId.class, View.SchemeById.class })
     @ManyToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-                fetch = FetchType.LAZY)
+                fetch = FetchType.EAGER)
     @JoinTable(
         name="SPANTYPE_LABELSET",
         joinColumns={@JoinColumn(name="LABEL_SET_ID", referencedColumnName="id")},
         inverseJoinColumns={@JoinColumn(name="SPANTYPE_ID", referencedColumnName="id")})
     private List<SpanType> appliesToSpanTypes = new ArrayList<>();
-    
+
     @JsonView({ View.SchemeByDocId.class, View.SchemeById.class })
     @OneToMany(mappedBy = "labelSet",
                 cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE },
@@ -72,7 +72,7 @@ public class LabelSet extends ColorableBaseEntity {
     public List<SpanType> getAppliesToSpanTypes() { return appliesToSpanTypes; }
 
     public void setAppliesToSpanTypes(List<SpanType> appliesToSpanTypes) { this.appliesToSpanTypes = appliesToSpanTypes; }
-    
+
     public void addAppliesToSpanTypes(SpanType spanType) { this.appliesToSpanTypes.add(spanType); }
 
     public List<Label> getLabels() { return labels; }
@@ -82,5 +82,5 @@ public class LabelSet extends ColorableBaseEntity {
     public LabelMenuStyle getLabelMenuStyle() { return labelMenuStyle; }
 
     public void setLabelMenuStyle(LabelMenuStyle labelMenuStyle) { this.labelMenuStyle = labelMenuStyle; }
-    
+
 }

--- a/src/main/java/de/unisaarland/swan/entities/SpanType.java
+++ b/src/main/java/de/unisaarland/swan/entities/SpanType.java
@@ -51,7 +51,7 @@ public class SpanType extends ColorableBaseEntity {
     @JsonIgnore
     @ManyToMany(mappedBy = "appliesToSpanTypes",
                 cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-                fetch = FetchType.LAZY)
+                fetch = FetchType.EAGER)
     private List<LabelSet> labelSets = new ArrayList<>();
 
 


### PR DESCRIPTION
In certain circumstances, the appliesToSpanTypes attribute was empty for Schemes,
even though it had been defined and was present in the database. This resulted
in an inability to choose labels during annotation.
The problem has been fixed by changing the FetchType for the labelSets and spanTypes
to EAGER, which should make sure that all necessary information is fetched in time.
