### PR TITLE
DA-298: Fix error when opening documents in projects not on first page

### DIFF
--- a/src/main/webapp/controllers/annotationController.js
+++ b/src/main/webapp/controllers/annotationController.js
@@ -50,7 +50,7 @@ angular
                 this.linkData = linkService.getLinks($window.sessionStorage.shownUser, $window.sessionStorage.docId);
                 this.tokenData = tokenService.getTokens($window.sessionStorage.docId);
                 // Retrieve projects and process projects
-                var httpProjects = $rootScope.loadProjects();   // TODO different query this is really inefficient
+                var httpProjects = $rootScope.loadProjects($window.sessionStorage.pageNumber);   // TODO different query this is really inefficient
                 // Wait for projects to be processed
                 $q.all([httpProjects]).then(function () {
                     $rootScope.buildTableProjects();
@@ -67,9 +67,10 @@ angular
              * @param {String} docName name
              * @param {String} projectName the Projects name
              * @param {Boolean} completed state of the document
+			 * @param {Integer} the page number the project is listed on
              */
             $scope.openAnnoTool = function (docId, docName, projectName, completed) {
-                $rootScope.initAnnoTool(docId, docName, projectName, completed);
+                $rootScope.initAnnoTool(docId, docName, projectName, completed, $window.sessionStorage.pageNumber);
                 $window.location.reload();
             };
 

--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -25,7 +25,7 @@ angular
                 $rootScope.collapsed = {};
                 $scope.currentPageNumber = 1;
                 var httpNumberProjects = $rootScope.loadProjectsCount();
-                var httpProjects = $rootScope.loadProjects();
+                var httpProjects = $rootScope.loadProjects($scope.currentPageNumber);
                 var httpSchemes = $scope.loadSchemes();
                 // Wait for http requests to be answered
                 $q.all([httpNumberProjects, httpProjects, httpSchemes]).then(function () {
@@ -150,7 +150,7 @@ angular
              */
             $scope.openAnnoTool = function (docId, docName, projectName, completed, users) {
                 $scope.alertVisible = true;
-                $rootScope.initAnnoTool(docId, docName, projectName, completed);
+                $rootScope.initAnnoTool(docId, docName, projectName, completed, $scope.currentPageNumber);
                 //Variables in the sessionStorage have to be Strings
                 $window.sessionStorage.users = JSON.stringify(users);
                 $location.path('/annotation');

--- a/src/main/webapp/controllers/rootController.js
+++ b/src/main/webapp/controllers/rootController.js
@@ -71,7 +71,7 @@ angular
         /**
          * Load projects depending on the user role from the backend.
          */
-        $rootScope.loadProjects = function (page = 1) {
+        $rootScope.loadProjects = function (page) {
 
         	const url = "swan/project/byuser/";
 
@@ -395,11 +395,12 @@ angular
          * @param {String} projectName the Projects name
          * @param {Boolean} completed state of the document
          */
-        $rootScope.initAnnoTool = function (docId, docName, projectName, completed) {
+        $rootScope.initAnnoTool = function (docId, docName, projectName, completed, pageNumber) {
             $window.sessionStorage.docId = docId;
             $window.sessionStorage.title = docName;
             $window.sessionStorage.project = projectName;
             $window.sessionStorage.completed = completed;
+			$window.sessionStorage.pageNumber = pageNumber;
         };
 
     }

--- a/src/main/webapp/controllers/tutorialController.js
+++ b/src/main/webapp/controllers/tutorialController.js
@@ -45,7 +45,7 @@ angular
 	        "</div>" +
 	        "</div>";
         
-        var httpProjects = $rootScope.loadProjects();
+        var httpProjects = $rootScope.loadProjects(1);
         $q.all([httpProjects]).then(function () {
         	
             $rootScope.buildTableProjects();
@@ -396,7 +396,7 @@ angular
                         content: "Great, you already have an assigned project and document. Click 'Next' to check out the editor.",
                         placement: "bottom",
                         onNext: function () {
-                            $rootScope.initAnnoTool(redirect.docId, redirect.docName, redirect.projectName, redirect.completed);
+                            $rootScope.initAnnoTool(redirect.docId, redirect.docName, redirect.projectName, redirect.completed, 1);
                         }
                     });
                     if (redirect === undefined) {

--- a/src/main/webapp/templates/viselements/projectnavigation.html
+++ b/src/main/webapp/templates/viselements/projectnavigation.html
@@ -11,29 +11,28 @@ and open the template in the editor.
         class="unselectable"
         id="anno-navigation">
 
-    <div ng-repeat="proj in this.tableProjects">
-        <label>{{proj.name}}</label>
-        <table class="table">
-            <tr ng-repeat="doc in proj.documents">
-                <td>
-                    <a ng-if="doc.id != currDoc.id"
-                       ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)"
-                       style="cursor: pointer">
-                        {{doc.name}}
-                    </a>
-                    <a ng-if="doc.id == currDoc.id"
-                       ng-href
-                       ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)"
-                       style="color: gray; cursor: pointer">
-                        {{doc.name}}
-                    </a>
-                </td>
-                <td>
-                    <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
-                          class="glyphicon glyphicon-ok">
-                    </span>
-                </td>
-            </tr>
-        </table>
-    </div>
+
+    <label>{{this.currProj.name}}</label>
+    <table class="table">
+        <tr ng-repeat="doc in this.currProj.documents">
+            <td>
+                <a ng-if="doc.id != currDoc.id"
+                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.name, doc.completed)"
+                   style="cursor: pointer">
+                    {{doc.name}}
+                </a>
+                <a ng-if="doc.id == currDoc.id"
+                   ng-href
+                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.name, doc.completed)"
+                   style="color: gray; cursor: pointer">
+                    {{doc.name}}
+                </a>
+            </td>
+            <td>
+                <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
+                      class="glyphicon glyphicon-ok">
+                </span>
+            </td>
+        </tr>
+    </table>
 </uib-accordion-group>

--- a/src/main/webapp/tests/jasmine/rootControllerTest.js
+++ b/src/main/webapp/tests/jasmine/rootControllerTest.js
@@ -925,7 +925,7 @@ describe('Test rootController', function () {
          */
 
         it('Test initAnnoTool', function () {
-            $rootScope.initAnnoTool(3, 'DogName', 'ProjName', true);
+            $rootScope.initAnnoTool(3, 'DogName', 'ProjName', true, 1);
             expect($window.sessionStorage.docId).toEqual('3');
             expect($window.sessionStorage.title).toEqual('DogName');
             expect($window.sessionStorage.project).toEqual('ProjName');


### PR DESCRIPTION
Previously, opening a document in a project that was not listed on
the first page of the project explorer evoked an error and the
previous/next buttons did not work.

The project navigation has been modified to now only list the current
project and its documents.
