### PR TITLE
DA-298: Fix error when opening documents in projects not on first page

### DIFF
--- a/src/main/java/de/unisaarland/swan/rest/services/v1/ProjectFacadeREST.java
+++ b/src/main/java/de/unisaarland/swan/rest/services/v1/ProjectFacadeREST.java
@@ -44,19 +44,19 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
 
     @EJB
     Service service;
-    
+
     @EJB
     UsersDAO usersDAO;
 
     @EJB
     ProjectDAO projectDAO;
-    
+
     @EJB
     AnnotationDAO annotationDAO;
-    
+
     @EJB
     LinkDAO linkDAO;
-    
+
 
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
@@ -91,12 +91,12 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("/add/{projId}/{userId}")
     public Response addUserToProject(@PathParam("projId") Long projId, @PathParam("userId") Long userId) throws CloneNotSupportedException {
-        
+
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
             service.addUserToProject(projId, userId);
@@ -108,12 +108,12 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("/del/{projId}/{userId}")
     public Response deleteUserFromProject(@PathParam("projId") Long projId, @PathParam("userId") Long userId) {
-        
+
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
             service.removeUserFromProject(projId, userId);
@@ -125,7 +125,7 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("/addManager/{projId}/{userId}")
@@ -142,12 +142,12 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("/delManager/{projId}/{userId}")
     public Response deleteProjectManagerFromProject(@PathParam("projId") Long projId, @PathParam("userId") Long userId) {
-        
+
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
             service.removeProjectManagerFromProject(projId, userId);
@@ -159,12 +159,12 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("/addWatchingUser/{projId}/{userId}")
     public Response addWatchingUserToProject(@PathParam("projId") Long projId, @PathParam("userId") Long userId) {
-        
+
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
             service.addWatchingUserToProject(projId, userId);
@@ -176,12 +176,12 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("/delWatchingUser/{projId}/{userId}")
     public Response deleteWatchingUserFromProject(@PathParam("projId") Long projId, @PathParam("userId") Long userId) {
-        
+
         try {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
             service.removeWatchingUserFromProject(projId, userId);
@@ -219,8 +219,33 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         } catch (IllegalArgumentException e) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
-        
+
     }
+
+	@GET
+	@Path("/byId/{projId}")
+	@Produces({MediaType.APPLICATION_JSON})
+	public Response getProjectById(@PathParam("projId") Long projId) {
+
+		try {
+			LoginUtil.check(usersDAO.checkLogin(getSessionID()));
+
+			Project proj = (Project) projectDAO.find(projId, false);
+
+			return Response.ok(mapper.writerWithView(View.Projects.class)
+					.withRootName("project")
+					.writeValueAsString(proj))
+					.build();
+		} catch (SecurityException e) {
+			return Response.status(Response.Status.FORBIDDEN).build();
+		} catch (JsonProcessingException ex) {
+			Logger.getLogger(SchemeFacadeREST.class.getName()).log(Level.SEVERE, null, ex);
+			return Response.serverError().build();
+		} catch (IllegalArgumentException e) {
+			return Response.status(Response.Status.BAD_REQUEST).build();
+		}
+
+	}
 
     @GET
     @Path("/count/byuser/{userId}")
@@ -270,14 +295,14 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         }
 
     }
-    
+
     /**
      * This method returns a zip archive containing all Users annotations project
      * related. For each document and user pair will be a single .xml file
      * created in the de.unisaarland.disacnno.export.model format.
-     * 
+     *
      * @param projId
-     * @return 
+     * @return
      */
     @GET
     @Path("/export/{projId}")
@@ -288,10 +313,10 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
 
             Project proj = (Project) projectDAO.find(projId, false);
-            
+
             ExportUtil exportUtil = new ExportUtil(annotationDAO, linkDAO);
             File file = exportUtil.getExportDataInXML(proj);
-            
+
             return Response
                         .ok(FileUtils.readFileToByteArray(file))
                         .header("Content-Disposition", "attachment; filename=\"export_" + proj.getName() + ".zip\"")
@@ -304,16 +329,16 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         } catch (NoResultException e) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
-        
+
     }
-    
+
      /**
      * This method returns a zip archive containing all Users annotations project
      * related. For each document and user pair will be a single .xmi file
      * created in the UIMA format.
-     * 
+     *
      * @param projId
-     * @return 
+     * @return
      */
     @GET
     @Path("/exportXmi/{projId}")
@@ -324,10 +349,10 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
             LoginUtil.check(usersDAO.checkLogin(getSessionID(), Users.RoleType.projectmanager));
 
             Project proj = (Project) projectDAO.find(projId, false);
-            
+
             ExportUtil exportUtil = new ExportUtil(annotationDAO, linkDAO);
             File file = exportUtil.getExportDataInXMI(proj);
-            
+
             return Response
                         .ok(FileUtils.readFileToByteArray(file))
                         .header("Content-Disposition", "attachment; filename=\"exportXmi_" + proj.getName() + ".zip\"")
@@ -340,7 +365,7 @@ public class ProjectFacadeREST extends AbstractFacade<Project> {
         } catch (NoResultException e) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
-        
+
     }
 
     @POST

--- a/src/main/webapp/controllers/annotationController.js
+++ b/src/main/webapp/controllers/annotationController.js
@@ -49,12 +49,10 @@ angular
                 this.scheme = schemeService.getScheme($window.sessionStorage.docId);
                 this.linkData = linkService.getLinks($window.sessionStorage.shownUser, $window.sessionStorage.docId);
                 this.tokenData = tokenService.getTokens($window.sessionStorage.docId);
-                // Retrieve projects and process projects
-                var httpProjects = $rootScope.loadProjects();   // TODO different query this is really inefficient
+                // Retrieve project and process project
+                var httpProject = $rootScope.loadProjectById($window.sessionStorage.projectId);
                 // Wait for projects to be processed
-                $q.all([httpProjects]).then(function () {
-                    $rootScope.buildTableProjects();
-                    $rootScope.currProj = $rootScope.getProjectByProjectName($window.sessionStorage.project, $rootScope.tableProjects);
+                $q.all([httpProject]).then(function () {
                     $rootScope.currDoc = $rootScope.getDocumentByDocumentId($window.sessionStorage.docId, $rootScope.currProj);
                 });
 
@@ -65,11 +63,12 @@ angular
              *
              * @param {String} docId The document id to annotate
              * @param {String} docName name
-             * @param {String} projectName the Projects name
+			 * @param {String} projectId the project's id
+             * @param {String} projectName the project's name
              * @param {Boolean} completed state of the document
              */
-            $scope.openAnnoTool = function (docId, docName, projectName, completed) {
-                $rootScope.initAnnoTool(docId, docName, projectName, completed);
+            $scope.openAnnoTool = function (docId, docName, projectId, projectName, completed) {
+                $rootScope.initAnnoTool(docId, docName, projectId, projectName, completed);
                 $window.location.reload();
             };
 
@@ -97,7 +96,8 @@ angular
                 $window.sessionStorage.shownUser = form.elements["users"].value;
                 $scope.openAnnoTool($window.sessionStorage.docId,
                         $window.sessionStorage.title,
-                        $window.sessionStorage.project,
+                        $window.sessionStorage.projectId,
+						$window.sessionStorage.projectName,
                         $window.sessionStorage.completed);
             };
 
@@ -989,7 +989,8 @@ angular
                         }
 
                         found = true;
-                        $scope.openAnnoTool(doc.id, doc.name, $window.sessionStorage.project, doc.completed);
+                        $scope.openAnnoTool(doc.id, doc.name, $window.sessionStorage.projectId, 
+							$window.sessionStorage.projectName, doc.completed);
                     }
                 }
 

--- a/src/main/webapp/controllers/d3/d3AnnotationController.js
+++ b/src/main/webapp/controllers/d3/d3AnnotationController.js
@@ -9,7 +9,7 @@ angular
     .module('app')
     .controller('d3AnnotationController', ['$scope', '$window', function ($scope, $window) {
             
-        this.project = $window.sessionStorage.project;
+        this.projectName = $window.sessionStorage.projectName;
         this.title = $window.sessionStorage.title;
 
         $scope.isPunctuation = function (string) {

--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -25,7 +25,7 @@ angular
                 $rootScope.collapsed = {};
                 $scope.currentPageNumber = 1;
                 var httpNumberProjects = $rootScope.loadProjectsCount();
-                var httpProjects = $rootScope.loadProjects();
+                var httpProjects = $rootScope.loadProjects($scope.currentPageNumber);
                 var httpSchemes = $scope.loadSchemes();
                 // Wait for http requests to be answered
                 $q.all([httpNumberProjects, httpProjects, httpSchemes]).then(function () {
@@ -145,12 +145,13 @@ angular
              *
              * @param {String} docId The document id to annotate
              * @param {String} docName name
-             * @param {String} projectName the Projects name
+             * @param {String} projectId the project's id
+			 * @param {String} projectName the project's name
              * @param {Boolean} completed state of the document
              */
-            $scope.openAnnoTool = function (docId, docName, projectName, completed, users) {
+            $scope.openAnnoTool = function (docId, docName, projectId, projectName, completed, users) {
                 $scope.alertVisible = true;
-                $rootScope.initAnnoTool(docId, docName, projectName, completed);
+                $rootScope.initAnnoTool(docId, docName, projectId, projectName, completed);
                 //Variables in the sessionStorage have to be Strings
                 $window.sessionStorage.users = JSON.stringify(users);
                 $location.path('/annotation');

--- a/src/main/webapp/controllers/rootController.js
+++ b/src/main/webapp/controllers/rootController.js
@@ -71,7 +71,7 @@ angular
         /**
          * Load projects depending on the user role from the backend.
          */
-        $rootScope.loadProjects = function (page = 1) {
+        $rootScope.loadProjects = function (page) {
 
         	const url = "swan/project/byuser/";
 
@@ -84,6 +84,22 @@ angular
 
             return httpProjects;
         };
+
+		/**
+		 * Load project from database by project id.
+		 */
+		$rootScope.loadProjectById = function (id) {
+
+			const url = "swan/project/byId/" + id;
+
+			var httpProject = $http.get(url).success(function (response) {
+				$rootScope.currProj = JSOG.parse(JSON.stringify(response)).project;
+			}).error(function (response) {
+				$rootScope.checkResponseStatusCode(response.status);
+			});
+
+			return httpProject;
+		};
 
         $rootScope.loadProjectsCount = function () {
 
@@ -296,16 +312,6 @@ angular
             return false;
         };
 
-        $rootScope.getProjectByProjectName = function (projName, projects) {
-            for (var i = 0; i < projects.length; i++) {
-                const proj = projects[i];
-                if (proj.name === projName) {
-                    return proj;
-                }
-            }
-            throw "rootController: Project not found";
-        };
-
         $rootScope.getProjectByProjectId = function (projId, projects) {
             for (var i = 0; i < projects.length; i++) {
                 var proj = projects[i];
@@ -390,15 +396,17 @@ angular
         /**
          * Initialize the annotation tool
          *
-         * @param {String} docId The document id to annotate
+         * @param {String} docId the document id to annotate
          * @param {String} docName name
-         * @param {String} projectName the Projects name
+		 * @param {String} projectId the project's id
+         * @param {String} projectName the project's name
          * @param {Boolean} completed state of the document
          */
-        $rootScope.initAnnoTool = function (docId, docName, projectName, completed) {
+        $rootScope.initAnnoTool = function (docId, docName, projectId, projectName, completed) {
             $window.sessionStorage.docId = docId;
             $window.sessionStorage.title = docName;
-            $window.sessionStorage.project = projectName;
+            $window.sessionStorage.projectId = projectId;
+			$window.sessionStorage.projectName = projectName;
             $window.sessionStorage.completed = completed;
         };
 

--- a/src/main/webapp/controllers/tutorialController.js
+++ b/src/main/webapp/controllers/tutorialController.js
@@ -11,13 +11,13 @@ angular
     function ($scope, $rootScope, $window, $http, $uibModal, $q) {
 
     	$rootScope.validateSignedInUser();
-    	
+
         // Note: Unfortunately bootstrap-tour is a little buggy when
         // the tour redirects to another page. Therefore dummy entries
         // were added with 1 ms duration as a workaround. Additionally
         // the corresponding controllers have to check for the tour
         // in the $rootScope and resume if specified.
-        // For modals, the first step must have a delay of 1000, 
+        // For modals, the first step must have a delay of 1000,
         // allowing time for loading and updating the DOM.
 
         $scope.existsDocumentsInProjects = function (projects) {
@@ -27,13 +27,14 @@ angular
                     var doc = proj.documents[0];
                     return {"docId": doc.id,
                         "docName": doc.name,
-                        "projectName": proj.name,
+                        "projectId": proj.id,
+						"projectName": proj.name,
                         "completed": doc.completed};
                 }
             }
             return undefined;
         };
-        
+
         const popupDesign =
         	"<div class='popover tour'>" +
 	        "<div class='arrow'></div>" +
@@ -44,12 +45,12 @@ angular
 	        "<button class='btn btn-default' data-role='end'>End tour</button>" +
 	        "</div>" +
 	        "</div>";
-        
-        var httpProjects = $rootScope.loadProjects();
+
+        var httpProjects = $rootScope.loadProjects(1);
         $q.all([httpProjects]).then(function () {
-        	
+
             $rootScope.buildTableProjects();
-        	
+
             // project manager tour
             if ($window.sessionStorage.role === 'admin' || $window.sessionStorage.role === "projectmanager") {
 
@@ -396,7 +397,7 @@ angular
                         content: "Great, you already have an assigned project and document. Click 'Next' to check out the editor.",
                         placement: "bottom",
                         onNext: function () {
-                            $rootScope.initAnnoTool(redirect.docId, redirect.docName, redirect.projectName, redirect.completed);
+                            $rootScope.initAnnoTool(redirect.docId, redirect.docName, redirect.projectId, redirect.projectName, redirect.completed);
                         }
                     });
                     if (redirect === undefined) {

--- a/src/main/webapp/templates/annotation.html
+++ b/src/main/webapp/templates/annotation.html
@@ -15,7 +15,7 @@ and open the template in the editor.
                 <div class="row">
                     <div class="col-md-8" id="1-anno-tool" ng-controller="d3AnnotationController as d3Anno">
                         <label class="headerinfo">Project: </label>
-                        <label class="infotitle">{{d3Anno.project}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                        <label class="infotitle">{{d3Anno.projectName}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
                         <label class="headerinfo">Document: </label>
                         <label class="infotitle">{{d3Anno.title}}</label>
                         <label ng-hide="isUnprivileged == 'false'">&nbsp;&nbsp;&nbsp;&nbsp;</label>

--- a/src/main/webapp/templates/projects/projects.html
+++ b/src/main/webapp/templates/projects/projects.html
@@ -133,7 +133,7 @@ and open the template in the editor.
                                 <a style="cursor: pointer"
                                    ng-href
                                    ng-hide="x.documents.length == 0 || isUnprivileged === 'false'"
-                                   ng-click="openAnnoTool(x.lastEditedDocument.id, x.lastEditedDocument.name, x.name, x.lastEditedDocument.completed)">
+                                   ng-click="openAnnoTool(x.lastEditedDocument.id, x.lastEditedDocument.name, x.id, x.name, x.lastEditedDocument.completed)">
                                         {{x.lastEditedDocument.name}}
                                 </a>
                             </td>
@@ -222,11 +222,11 @@ and open the template in the editor.
                                     <!-- Show open eye for admin/ project manager and pencil for user -->
                                     <span class="glyphicon glyphicon-eye-open"
                                           ng-hide="isUnprivileged === 'true'"
-                                          ng-click="openAnnoTool(doc.id, doc.name, x.name, doc.completed, x.users)">
+                                          ng-click="openAnnoTool(doc.id, doc.name, x.id, x.name, doc.completed, x.users)">
                                     </span>
                                     <span class="glyphicon glyphicon-pencil"
                                           ng-hide="isUnprivileged === 'false'"
-                                          ng-click="openAnnoTool(doc.id, doc.name, x.name, doc.completed, x.users)">
+                                          ng-click="openAnnoTool(doc.id, doc.name, x.id, x.name, doc.completed, x.users)">
                                     </span>
                                 </a>
                             </td>

--- a/src/main/webapp/templates/viselements/projectnavigation.html
+++ b/src/main/webapp/templates/viselements/projectnavigation.html
@@ -11,29 +11,28 @@ and open the template in the editor.
         class="unselectable"
         id="anno-navigation">
 
-    <div ng-repeat="proj in this.tableProjects">
-        <label>{{proj.name}}</label>
-        <table class="table">
-            <tr ng-repeat="doc in proj.documents">
-                <td>
-                    <a ng-if="doc.id != currDoc.id"
-                       ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)"
-                       style="cursor: pointer">
-                        {{doc.name}}
-                    </a>
-                    <a ng-if="doc.id == currDoc.id"
-                       ng-href
-                       ng-click="openAnnoTool(doc.id, doc.name, proj.name, doc.completed)"
-                       style="color: gray; cursor: pointer">
-                        {{doc.name}}
-                    </a>
-                </td>
-                <td>
-                    <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
-                          class="glyphicon glyphicon-ok">
-                    </span>
-                </td>
-            </tr>
-        </table>
-    </div>
+
+    <label>{{this.currProj.name}}</label>
+    <table class="table">
+        <tr ng-repeat="doc in this.currProj.documents">
+            <td>
+                <a ng-if="doc.id != currDoc.id"
+                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.id, this.currProj.name, doc.completed)"
+                   style="cursor: pointer">
+                    {{doc.name}}
+                </a>
+                <a ng-if="doc.id == currDoc.id"
+                   ng-href
+                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.id, this.currProj.name, doc.completed)"
+                   style="color: gray; cursor: pointer">
+                    {{doc.name}}
+                </a>
+            </td>
+            <td>
+                <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
+                      class="glyphicon glyphicon-ok">
+                </span>
+            </td>
+        </tr>
+    </table>
 </uib-accordion-group>

--- a/src/main/webapp/tests/jasmine/rootControllerTest.js
+++ b/src/main/webapp/tests/jasmine/rootControllerTest.js
@@ -748,38 +748,7 @@ describe('Test rootController', function () {
 
             expect(boolVal).toEqual(false);
         });
-
-
-        /**
-         * Test 'getProjectByProjectName'
-         */
-
-        it('Test getProjectByProjectName with 3 different projects', function () {
-            var projects = [
-                {name: 'DiscourseModeProj'},
-                {name: 'GreekProj'},
-                {name: 'Proj1'}
-            ];
-            var nameExists = 'Proj1';
-            var nameNotExists = 'Proj2';
-            var proj = $rootScope.getProjectByProjectName(nameExists, projects);
-
-            expect(proj.name).toEqual(nameExists);
-
-            expect(function () {
-                $rootScope.getProjectByProjectName(nameNotExists, projects);
-            }).toThrow();
-        });
-
-        it('Test getProjectByProjectName with empty projects', function () {
-            var projects = [ ];
-            var name = 'Proj1';
-
-            expect(function () {
-                $rootScope.getProjectByProjectName(name, projects);
-            }).toThrow();
-        });
-
+		
 
         /**
          * Test 'getProjectByProjectId'
@@ -925,10 +894,11 @@ describe('Test rootController', function () {
          */
 
         it('Test initAnnoTool', function () {
-            $rootScope.initAnnoTool(3, 'DogName', 'ProjName', true);
+            $rootScope.initAnnoTool(3, 'DogName', 1, 'ProjName', true);
             expect($window.sessionStorage.docId).toEqual('3');
             expect($window.sessionStorage.title).toEqual('DogName');
-            expect($window.sessionStorage.project).toEqual('ProjName');
+			expect($window.sessionStorage.projectId).toEqual('1');
+            expect($window.sessionStorage.projectName).toEqual('ProjName');
             expect($window.sessionStorage.completed).toEqual('true');
         });
 


### PR DESCRIPTION
Previously, opening a document in a project that was not listed on
the first page of the project explorer evoked an error and the
previous/next buttons did not work.

The project navigation has been modified to now only list the current
project and its documents.
