### PR TITLE
DA-304: Fix issues with completion checkbox

### DIFF
--- a/src/main/webapp/controllers/projects/projectsController.js
+++ b/src/main/webapp/controllers/projects/projectsController.js
@@ -147,11 +147,11 @@ angular
              * @param {String} docName name
              * @param {String} projectId the project's id
 			 * @param {String} projectName the project's name
-             * @param {Boolean} completed state of the document
+             * @param {String} tokenizationLang tokenization language of the project
              */
-            $scope.openAnnoTool = function (docId, docName, projectId, projectName, completed, users) {
+            $scope.openAnnoTool = function (docId, docName, projectId, projectName, tokenizationLang, users) {
                 $scope.alertVisible = true;
-                $rootScope.initAnnoTool(docId, docName, projectId, projectName, completed);
+                $rootScope.initAnnoTool(docId, docName, projectId, projectName, tokenizationLang);
                 //Variables in the sessionStorage have to be Strings
                 $window.sessionStorage.users = JSON.stringify(users);
                 $location.path('/annotation');

--- a/src/main/webapp/controllers/rootController.js
+++ b/src/main/webapp/controllers/rootController.js
@@ -247,7 +247,7 @@ angular
             return {documents: documents, projComplAdmin: projComplAdmin};
         };
 
-        $scope.buildDocumentsUnprivileged = function (proj, documents) {
+        $scope.buildDocumentsUnprivileged = function (proj) {
 
 			var documents = [];
 
@@ -277,9 +277,6 @@ angular
                 if (stateTarget == undefined) {
                     throw "rootController: No corresponding state object existing";
                 }
-                if (lastEdit > lastEditedDocComp.lastEdit) {
-                    lastEditedDocComp = { lastEditedDocument: doc, lastEdit: lastEdit };
-                }
 
                 const docTemplate = {
                     'id': doc.id,
@@ -289,12 +286,49 @@ angular
                     'lastEdit': lastEdit
                 };
                 documents.push(docTemplate);
+
+				if (lastEdit > lastEditedDocComp.lastEdit) {
+					lastEditedDocComp = { lastEditedDocument: docTemplate, lastEdit: lastEdit };
+				}
             }
             // Sort the documents alphabetically
             documents.sort($rootScope.compareDocumentsByName);
 
             return {documents: documents, lastEditedDocument: lastEditedDocComp.lastEditedDocument, projComplUser: projComplUser};
         };
+
+		$rootScope.buildDocumentsByAnnotator = function (proj, userId) {
+			
+			var documents = [];
+
+			for (var j = 0; j < proj.documents.length; j++) {
+
+				const doc = proj.documents[j];
+				var docCompl;
+
+				var stateTarget;
+				for (var t = 0; t < doc.states.length; t++) {
+					const state = doc.states[t];
+					if (userId == state.user.id) {
+						stateTarget = state;
+						docCompl = state.completed;
+						break;
+					}
+				}
+
+				const docTemplate = {
+					'id': doc.id,
+					'name': doc.name,
+					'completed': docCompl,
+				};
+				documents.push(docTemplate);
+			}
+
+			// Sort the documents alphabetically
+			documents.sort($rootScope.compareDocumentsByName);
+			
+			return documents;
+		};
 
         $rootScope.getUserIdIndexMap = function (users) {
             var userIdIndexMap = {};
@@ -326,9 +360,9 @@ angular
             throw "rootController: Project not found";
         };
 
-        $rootScope.getDocumentByDocumentId = function (docId, project) {
-            for (var i = 0; i < project.documents.length; i++) {
-                var doc = project.documents[i];
+        $rootScope.getDocumentByDocumentId = function (docId, documents) {
+            for (var i = 0; i < documents.length; i++) {
+                var doc = documents[i];
                 if (doc.id == docId) {
                     return doc;
                 }
@@ -404,14 +438,14 @@ angular
          * @param {String} docName name
 		 * @param {String} projectId the project's id
          * @param {String} projectName the project's name
-         * @param {Boolean} completed state of the document
+         * @param {String} tokenizationLang tokenization language of the project
          */
-        $rootScope.initAnnoTool = function (docId, docName, projectId, projectName, completed) {
+        $rootScope.initAnnoTool = function (docId, docName, projectId, projectName, tokenizationLang) {
             $window.sessionStorage.docId = docId;
             $window.sessionStorage.title = docName;
             $window.sessionStorage.projectId = projectId;
 			$window.sessionStorage.projectName = projectName;
-            $window.sessionStorage.completed = completed;
+            $window.sessionStorage.tokenizationLang = tokenizationLang;
         };
 
     }

--- a/src/main/webapp/controllers/tutorialController.js
+++ b/src/main/webapp/controllers/tutorialController.js
@@ -29,7 +29,7 @@ angular
                         "docName": doc.name,
                         "projectId": proj.id,
 						"projectName": proj.name,
-                        "completed": doc.completed};
+                        "tokenizationLang": proj.tokenizationLang};
                 }
             }
             return undefined;
@@ -397,7 +397,7 @@ angular
                         content: "Great, you already have an assigned project and document. Click 'Next' to check out the editor.",
                         placement: "bottom",
                         onNext: function () {
-                            $rootScope.initAnnoTool(redirect.docId, redirect.docName, redirect.projectId, redirect.projectName, redirect.completed);
+                            $rootScope.initAnnoTool(redirect.docId, redirect.docName, redirect.projectId, redirect.projectName, redirect.tokenizationLang);
                         }
                     });
                     if (redirect === undefined) {

--- a/src/main/webapp/directives/d3Annotation.js
+++ b/src/main/webapp/directives/d3Annotation.js
@@ -1363,7 +1363,7 @@ angular
 						}
 					}
 
-					if ($rootScope.currProj.tokenizationLang === "Characterwise") {
+					if ($window.sessionStorage.tokenizationLang === "Characterwise") {
 						return len + 3; // Add 3 pixels to account for space between tokens
 					}
 					else {

--- a/src/main/webapp/templates/annotation.html
+++ b/src/main/webapp/templates/annotation.html
@@ -17,11 +17,10 @@ and open the template in the editor.
                         <label class="headerinfo">Project: </label>
                         <label class="infotitle">{{d3Anno.projectName}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
                         <label class="headerinfo">Document: </label>
-                        <label class="infotitle">{{d3Anno.title}}</label>
-                        <label ng-hide="isUnprivileged == 'false'">&nbsp;&nbsp;&nbsp;&nbsp;</label>
+                        <label class="infotitle">{{d3Anno.title}}&nbsp;&nbsp;&nbsp;&nbsp;</label>
                         <div style="display: inline-block;"
                              ng-controller="annotationController as annoCon"
-                             ng-hide="isUnprivileged == 'false'" align="right">
+                             ng-hide="isUnprivileged=='false' && completed==undefined" align="right">
                             <input type="checkbox"
                                    value=""
                                    style="margin: 0px;"

--- a/src/main/webapp/templates/projects/projects.html
+++ b/src/main/webapp/templates/projects/projects.html
@@ -133,7 +133,7 @@ and open the template in the editor.
                                 <a style="cursor: pointer"
                                    ng-href
                                    ng-hide="x.documents.length == 0 || isUnprivileged === 'false'"
-                                   ng-click="openAnnoTool(x.lastEditedDocument.id, x.lastEditedDocument.name, x.id, x.name, x.lastEditedDocument.completed)">
+                                   ng-click="openAnnoTool(x.lastEditedDocument.id, x.lastEditedDocument.name, x.id, x.name, x.tokenizationLang, x.users)">
                                         {{x.lastEditedDocument.name}}
                                 </a>
                             </td>
@@ -206,7 +206,7 @@ and open the template in the editor.
                                     <div class="progress-bar progress-bar-success"
                                          role="progressbar"
                                          aria-valuenow="{{doc.completed}}"
-                                         aria-valuemin="0"
+                                         aria-valuemin="0"us
                                          aria-valuemax="x.users.length"
                                          style="width: {{100 * doc.completed / x.users.length}}%;">
                                         <span>{{doc.completed}}/{{x.users.length}}</span>
@@ -222,11 +222,11 @@ and open the template in the editor.
                                     <!-- Show open eye for admin/ project manager and pencil for user -->
                                     <span class="glyphicon glyphicon-eye-open"
                                           ng-hide="isUnprivileged === 'true'"
-                                          ng-click="openAnnoTool(doc.id, doc.name, x.id, x.name, doc.completed, x.users)">
+                                          ng-click="openAnnoTool(doc.id, doc.name, x.id, x.name, x.tokenizationLang, x.users)">
                                     </span>
                                     <span class="glyphicon glyphicon-pencil"
                                           ng-hide="isUnprivileged === 'false'"
-                                          ng-click="openAnnoTool(doc.id, doc.name, x.id, x.name, doc.completed, x.users)">
+                                          ng-click="openAnnoTool(doc.id, doc.name, x.id, x.name, x.tokenizationLang, x.users)">
                                     </span>
                                 </a>
                             </td>

--- a/src/main/webapp/templates/viselements/projectnavigation.html
+++ b/src/main/webapp/templates/viselements/projectnavigation.html
@@ -14,22 +14,22 @@ and open the template in the editor.
 
     <label>{{this.currProj.name}}</label>
     <table class="table">
-        <tr ng-repeat="doc in this.currProj.documents">
+        <tr ng-repeat="doc in this.documents">
             <td>
                 <a ng-if="doc.id != currDoc.id"
-                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.id, this.currProj.name, doc.completed)"
+                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.id, this.currProj.name, this.currProj.tokenizationLang)"
                    style="cursor: pointer">
                     {{doc.name}}
                 </a>
                 <a ng-if="doc.id == currDoc.id"
                    ng-href
-                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.id, this.currProj.name, doc.completed)"
+                   ng-click="openAnnoTool(doc.id, doc.name, this.currProj.id, this.currProj.name, this.currProj.tokenizationLang)"
                    style="color: gray; cursor: pointer">
                     {{doc.name}}
                 </a>
             </td>
             <td>
-                <span ng-hide="doc.completed === false || isUnprivileged == 'false'"
+                <span ng-hide="doc.completed === false || doc.completed === undefined"
                       class="glyphicon glyphicon-ok">
                 </span>
             </td>

--- a/src/main/webapp/tests/jasmine/rootControllerTest.js
+++ b/src/main/webapp/tests/jasmine/rootControllerTest.js
@@ -977,26 +977,23 @@ describe('Test rootController', function () {
                 {id: 3}
             ];
 
-            var project = {documents: documents};
-
             var idExists = 1;
             var idNotExists = 4;
-            var proj = $rootScope.getDocumentByDocumentId(idExists, project);
+            var proj = $rootScope.getDocumentByDocumentId(idExists, documents);
 
             expect(proj.id).toEqual(idExists);
 
             expect(function () {
-                $rootScope.getDocumentByDocumentId(idNotExists, project);
+                $rootScope.getDocumentByDocumentId(idNotExists, documents);
             }).toThrow();
         });
 
         it('Test getDocumentByDocumentId with empty projects', function () {
             var documents = [ ];
-            var project = {documents: documents};
             var id = 1;
 
             expect(function () {
-                $rootScope.getDocumentByDocumentId(id, project);
+                $rootScope.getDocumentByDocumentId(id, documents);
             }).toThrow();
         });
 
@@ -1079,12 +1076,12 @@ describe('Test rootController', function () {
          */
 
         it('Test initAnnoTool', function () {
-            $rootScope.initAnnoTool(3, 'DogName', 1, 'ProjName', true);
+            $rootScope.initAnnoTool(3, 'DogName', 1, 'ProjName', 'English');
             expect($window.sessionStorage.docId).toEqual('3');
             expect($window.sessionStorage.title).toEqual('DogName');
 			expect($window.sessionStorage.projectId).toEqual('1');
             expect($window.sessionStorage.projectName).toEqual('ProjName');
-            expect($window.sessionStorage.completed).toEqual('true');
+            expect($window.sessionStorage.tokenizationLang).toEqual('English');
         });
 
     });


### PR DESCRIPTION
Previously, the completion status was not displayed correctly in the
project navigation bar, and the completion checkbox was never checked when
the project was not opened from the project explorer.
The completion checkbox is now also visible and accessible for admins and
project managers, allowing them to change the completion state of a document.

Additionally, an error that sometimes occurred in d3Annotation.js when
checking the tokenization language due to an asynchronous request was fixed.