### PR TITLE
DA-343: Don't allow adding several documents with the same name

### DIFF
--- a/src/main/webapp/controllers/projects/documentAddModalController.js
+++ b/src/main/webapp/controllers/projects/documentAddModalController.js
@@ -26,6 +26,7 @@ angular
 		$scope.removeDocument = function (fileName) {
 			delete $scope.textFileMap[fileName];
 			delete $scope.targetFileMap[fileName];
+			$("#text").val('');
 			$scope.numberOfDocuments -= 1;
 		};
 
@@ -79,6 +80,17 @@ angular
 					msg: "You have selected too many documents. The maximum number of documents allowed per project is 50."
 				});
 				return;
+			}
+			for (var i = 0; i < $rootScope.currProj.documents.length; i++) {
+				var docName = $rootScope.currProj.documents[i].name;
+				if ($scope.textFileMap[docName] != undefined) {
+					$rootScope.addAlert({
+						type: 'warning',
+						msg: "The document '" + docName + "' already exists in this project."
+					});
+					delete $scope.textFileMap[docName];
+					delete $scope.targetFileMap[docName];
+				}
 			}
             try {
                 for (var curFileName in $scope.textFileMap) {


### PR DESCRIPTION
- Before, it was possible to add the same document multiple times to
the same project. This is now not possible anymore.
- Before, it was not possible to remove a document in the documentAddModal
and then select it again. This was also fixed.