### PR TITLE
DA-281: Don't close schemeUploadModal when uploading invalid scheme

### DIFF
--- a/src/main/webapp/controllers/schemes/schemeUploadModalController.js
+++ b/src/main/webapp/controllers/schemes/schemeUploadModalController.js
@@ -203,6 +203,7 @@ angular
                         if ($rootScope.tour !== undefined) {
                             $("#tour-next-button").prop("disabled", false);
                         }
+						$uibModalInstance.close();
                     }).error(function (response) {
                         $rootScope.checkResponseStatusCode(response.status);
                         $rootScope.addAlert({type: 'danger', msg: 'A scheme with this name already exists.'});
@@ -809,7 +810,6 @@ angular
                 }
 
                 $scope.sendScheme();
-                $uibModalInstance.close();
             }
         };
 

--- a/src/main/webapp/tests/jasmine/schemeUploadModalControllerTest.js
+++ b/src/main/webapp/tests/jasmine/schemeUploadModalControllerTest.js
@@ -10,7 +10,7 @@
 describe('Test schemeUploadModalController', function () {
     beforeEach(module('app'));
 
-    var $controller, $injector, $scope, $rootScope, $window, $http, $sce, $uibModal, $uibModalInstance, $timeout, $location;
+    var $controller, $injector, $scope, $rootScope, $window, $http, $sce, $uibModal, $uibModalInstance, $timeout;
     var controller, rootController, schemesController, UtilityService;
 
     // For asynchronous statements and promises
@@ -27,6 +27,7 @@ describe('Test schemeUploadModalController', function () {
         $window = _$window_;
         $http = _$http_;
         $timeout = _$timeout_;
+		$uibModalInstance = {};
 
         $window.sessionStorage.role = 'admin';
         $window.sessionStorage.isAnnotator = 'false';
@@ -546,6 +547,9 @@ describe('Test schemeUploadModalController', function () {
             $httpBackend
                 .expect('POST', url);
 
+			$uibModalInstance.close = {};
+			spyOn($uibModalInstance, "close").and.callFake(function () {});
+
             $scope.timelineView.checked = true;
             $scope.noView.checked = false;
             $scope.linkTypes.push(timelineLinkType);
@@ -567,6 +571,7 @@ describe('Test schemeUploadModalController', function () {
             expect($rootScope.tableSchemes.length).toEqual(1);
             var preview = $rootScope.tableSchemes[0];
             expect(preview.name).toEqual($scope.schemeName);
+			expect($uibModalInstance.close).toHaveBeenCalled();
         });
 
     });


### PR DESCRIPTION
Previously the modal was closed when trying to upload an invalid scheme and changes were lost.
In practice, this case should be irrelevant, because it should not be possible to create invalid schemes in the first place.